### PR TITLE
🛠️ 監査 issue (#116–#143) 対応: セキュリティ・堅牢性・CI・ドキュメント改善

### DIFF
--- a/.github/workflows/check_pull_request.yml
+++ b/.github/workflows/check_pull_request.yml
@@ -34,7 +34,7 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: Build with Gradle
-        run: ./gradlew build -x test
+        run: ./gradlew build
 
       - name: Set final commit status
         uses: myrotvorets/set-commit-status-action@master

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -69,11 +69,9 @@ jobs:
         run: chmod +x ./gradlew
 
       - name: Run tests
-        continue-on-error: true
         run: ./gradlew test
 
       - name: Run detekt
-        continue-on-error: true
         run: ./gradlew detekt
 
       - name: Build with Gradle

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '25'
           cache: 'gradle'
 
       - name: Change wrapper permissions

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -9,12 +9,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           distribution: 'temurin'
-          java-version: '17'
+          java-version: '25'
           cache: 'gradle'
 
       - name: Change wrapper permissions

--- a/README.md
+++ b/README.md
@@ -1,15 +1,41 @@
-# NoticeTemplate
+# AdvanceRailway
 
-Please delete this README after copying
+AdvanceRailway is a [Paper](https://papermc.io/)/Bukkit plugin that lets you build and manage in-game railway
+networks: stations, railway lines, and groups of lines. It renders the network on the
+[squaremap](https://github.com/jpenilla/squaremap) web map and, when the MineAuth plugin is present,
+exposes a read-only HTTP API for querying stations, railways, and groups as JSON.
 
-## License 
-Written in 2022 by Nikomaru &emsp; No Rights Reserved. <br>
+## Features
 
-To the extent possible under law, Nikomaru has waived all copyright and related or neighboring rights to NoticeTemplate. This work is published from: Japan.<br>
+- Define stations and railways with commands, stored as JSON under the plugin's data folder.
+- Group railway lines together (e.g. by line color/name) via `GroupData`.
+- Draw stations and railway lines as markers on the squaremap live map (optional soft dependency).
+- Optional MineAuth integration that publishes `/api/v1/plugins/advancerailway/` HTTP endpoints for
+  stations, railways, and groups (list + get-by-id). See the docs site for the full API reference.
 
-You should have received a copy of the CC0 Public Domain Dedication along with this software. If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+## Building
 
-## Usage
-### github
-1. Use this template
-2. To go `Settings` > `Actions` > `General` > `Workflow permissions` > `Check Read and write permission`
+AdvanceRailway targets Java 25 and is built with Gradle.
+
+```bash
+./gradlew build
+```
+
+This compiles the plugin, runs [detekt](https://detekt.dev/) static analysis, runs the test suite, and
+produces a shaded jar under `build/libs/`.
+
+To run a local Paper test server with the plugin loaded:
+
+```bash
+./gradlew runServer
+```
+
+## Documentation
+
+Full documentation (setup, commands, usage, and the MineAuth HTTP API) is published at
+<https://advance-railway.nikomaru.page>, built from the [`docs/`](docs) directory with
+[MkDocs Material](https://squidfunk.github.io/mkdocs-material/).
+
+## License
+
+See the repository for license details.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -158,6 +158,27 @@ sourceSets.main {
                         "advancerailway.command.common"
                     )
                 }
+                // 旧来の粗い（coarse）ノードは read/write 双方の親として残し、
+                // 既存の付与（admin → coarse → read+write）をそのまま維持する。
+                // write リーフには default を付けない（op 以外に書き込みを与えないため）。
+                register("advancerailway.command.group") {
+                    children(
+                        "advancerailway.command.group.read",
+                        "advancerailway.command.group.write"
+                    )
+                }
+                register("advancerailway.command.station") {
+                    children(
+                        "advancerailway.command.station.read",
+                        "advancerailway.command.station.write"
+                    )
+                }
+                register("advancerailway.command.railway") {
+                    children(
+                        "advancerailway.command.railway.read",
+                        "advancerailway.command.railway.write"
+                    )
+                }
             }
             apiVersion = "1.21"
         }

--- a/docs/docs/en/index.md
+++ b/docs/docs/en/index.md
@@ -1,5 +1,21 @@
-# About PluginTemplate
+# About AdvanceRailway
 
-This is a template for creating a plugin for the [Minecraft](https://www.minecraft.net/) server
-software [Paper](https://papermc.io/).
+AdvanceRailway is a plugin for the [Minecraft](https://www.minecraft.net/) server
+software [Paper](https://papermc.io/) that adds railway stations and railway lines to your server.
 
+## What it does
+
+- **Stations** — define named stations with a world, position, numbering, and optional color/size, used as
+  the endpoints of railway lines.
+- **Railways** — connect two stations with a line (type, required travel time, and the points used to draw
+  it), optionally organized into **groups** (e.g. to color-code a line family).
+- **squaremap integration** — when [squaremap](https://github.com/jpenilla/squaremap) is installed, stations
+  and railway lines are drawn as markers on the live web map.
+- **MineAuth HTTP API** — when the MineAuth plugin is installed, AdvanceRailway publishes read-only HTTP
+  endpoints for stations, railways, and groups. See [MineAuth HTTP API](mineauth-api.md) for the full
+  reference.
+
+## Getting started
+
+Use the in-game commands to create stations, railways, and groups. For details on the read-only HTTP API,
+see [MineAuth HTTP API](mineauth-api.md).

--- a/docs/docs/en/mineauth-api.md
+++ b/docs/docs/en/mineauth-api.md
@@ -1,0 +1,122 @@
+# MineAuth HTTP API
+
+When the MineAuth plugin is installed alongside AdvanceRailway (MineAuth is a soft dependency —
+AdvanceRailway works fine without it), AdvanceRailway registers a set of permission-gated, read-only HTTP endpoints under:
+
+```
+/api/v1/plugins/advancerailway/
+```
+
+If MineAuth is not installed, these endpoints are not registered and AdvanceRailway otherwise behaves
+normally.
+
+## Endpoints
+
+| Method | Path | Description |
+| --- | --- | --- |
+| GET | `/stations` | List all stations |
+| GET | `/stations/{id}` | Get a single station by id |
+| GET | `/railways` | List all railways |
+| GET | `/railways/{id}` | Get a single railway by id |
+| GET | `/groups` | List all groups |
+| GET | `/groups/{id}` | Get a single group by id |
+
+Paths above are relative to the `/api/v1/plugins/advancerailway/` base path, e.g. the full path for listing
+stations is `/api/v1/plugins/advancerailway/stations`.
+
+A by-id request for an id that does not exist returns an HTTP `404 Not Found` error.
+
+## Authentication / permissions
+
+All six endpoints are gated with the `@Permission("advancerailway.mineauth.read")` annotation, so a
+caller must hold the `advancerailway.mineauth.read` permission node (enforced by MineAuth) to read
+railway data. The endpoints expose exact in-world coordinates, so grant this node only to trusted
+callers.
+
+The integration can also be disabled entirely via config (`mineAuthEnabled: false` in the plugin
+config); when disabled, `MineAuthIntegration` does not register the handler even if MineAuth is present.
+
+## Pagination
+
+The list endpoints (`/stations`, `/railways`, `/groups`) accept `limit` and `offset` query parameters
+to bound the response and avoid an unbounded full-folder read:
+
+- `limit` — number of items to return. Default `100`, capped at `500`.
+- `offset` — number of items to skip. Default `0`.
+
+Example: `GET /api/v1/plugins/advancerailway/stations?limit=50&offset=100`
+
+## Response shapes
+
+All responses are JSON, encoded with `kotlinx.serialization`.
+
+### Station
+
+```json
+{
+  "id": "central",
+  "name": "Central Station",
+  "numbering": "M01",
+  "world": "world",
+  "point": { "x": 0.0, "y": 64.0, "z": 0.0 },
+  "overrideSize": null,
+  "color": "#FF0000"
+}
+```
+
+- `numbering` and `overrideSize` may be `null`.
+- `color` is a `#RRGGBB` hex string.
+
+`GET /stations` returns a list wrapped in an object:
+
+```json
+{ "stations": [ { "...": "StationDto" } ] }
+```
+
+`GET /stations/{id}` returns a single station object (unwrapped).
+
+### Railway
+
+```json
+{
+  "id": "central-to-north",
+  "group": "main-line",
+  "world": "world",
+  "lineType": "UP_LINE",
+  "fromStation": "central",
+  "toStation": "north",
+  "timeRequired": 30,
+  "startPoint": { "x": 0.0, "y": 64.0, "z": 0.0 },
+  "endPoint": { "x": 100.0, "y": 64.0, "z": 0.0 },
+  "directionPoint": { "x": 50.0, "y": 64.0, "z": 0.0 }
+}
+```
+
+- `group` may be `null` if the railway does not belong to a group.
+- `timeRequired` is the travel time in seconds.
+
+`GET /railways` returns:
+
+```json
+{ "railways": [ { "...": "RailwayDto" } ] }
+```
+
+`GET /railways/{id}` returns a single railway object (unwrapped).
+
+### Group
+
+```json
+{
+  "id": "main-line",
+  "name": "Main Line",
+  "color": "#00A0FF"
+}
+```
+
+`GET /groups` returns:
+
+```json
+{ "groups": [ { "...": "GroupDto" } ] }
+```
+
+`GET /groups/{id}` returns a single group object (unwrapped).

--- a/docs/docs/ja/usage/index.md
+++ b/docs/docs/ja/usage/index.md
@@ -15,20 +15,21 @@
 
 ## グループの作成
 
-`ar gropu register <id> <name>`を使用してグループを作成します
+`ar group add <groupId> <groupName>`を使用してグループを作成します
 
-- `id` : グループのID
-- `name` : グループの名前
+- `groupId` : グループのID
+- `groupName` : グループの名前
 
 ### 例
 
-`ar gropu register mr もりもと線`を実行すると、もりもと線というグループが作成されます。<br>
+`ar group add mr もりもと線`を実行すると、もりもと線というグループが作成されます。<br>
 
 ## 路線の追加
 
-`ar railway register <railwayId> <start> <direction> <end>`を使用して路線を追加します
+`ar railway add <railwayId> <railwayName> <start> <direction> <end>`を使用して路線を追加します
 
-- `id` : 路線のID
+- `railwayId` : 路線のID
+- `railwayName` : 路線の名前
 - `start` : 路線の始点
 - `direction` : 路線の方向
 - `end` : 路線の終点

--- a/src/main/kotlin/dev/nikomaru/advancerailway/AdvanceRailway.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/AdvanceRailway.kt
@@ -26,9 +26,12 @@ import dev.nikomaru.advancerailway.commands.station.StationMainCommand
 import dev.nikomaru.advancerailway.file.FileLoader
 import dev.nikomaru.advancerailway.listener.RailClickEvent
 import dev.nikomaru.advancerailway.mineauth.MineAuthIntegration
+import dev.nikomaru.advancerailway.utils.command.GroupIdParser
 import dev.nikomaru.advancerailway.utils.command.GroupIdParser.registerGroupIdParser
 import dev.nikomaru.advancerailway.utils.command.Point3DParser.registerPoint3DParser
+import dev.nikomaru.advancerailway.utils.command.RailwayIdParser
 import dev.nikomaru.advancerailway.utils.command.RailwayIdParser.registerRailwayIdParser
+import dev.nikomaru.advancerailway.utils.command.StationIdParser
 import dev.nikomaru.advancerailway.utils.command.StationIdParser.registerStationIdParser
 import org.bukkit.Bukkit
 import org.koin.core.context.GlobalContext
@@ -50,6 +53,7 @@ open class AdvanceRailway: SuspendingJavaPlugin() {
         setCommand()
         setEventHandlers()
         setupKoin()
+        ensureCommandDataFolders()
         settingMap()
         FileLoader.load()
         // MineAuth が導入されていれば HTTP エンドポイントを登録する（未導入でも動作する）。
@@ -67,6 +71,17 @@ open class AdvanceRailway: SuspendingJavaPlugin() {
             single { squaremapApi }
             single { provider }
         })
+    }
+
+    /**
+     * Creates the data/{groups,railways,stations} folders used by the id parsers' suggestions.
+     * Must run after [setupKoin], since it resolves the Koin-injected plugin instance; the id
+     * parsers' own `suggestions()` deliberately stays read-only and never creates these folders.
+     */
+    private fun ensureCommandDataFolders() {
+        GroupIdParser.ensureDataFolder()
+        RailwayIdParser.ensureDataFolder()
+        StationIdParser.ensureDataFolder()
     }
 
     private fun setupKoin() {

--- a/src/main/kotlin/dev/nikomaru/advancerailway/commands/CommandUtils.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/commands/CommandUtils.kt
@@ -1,0 +1,50 @@
+/*
+ * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ *
+ * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication along with this software.
+ * If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+package dev.nikomaru.advancerailway.commands
+
+import arrow.core.Either
+import dev.nikomaru.advancerailway.AdvanceRailway
+import org.bukkit.command.CommandSender
+import java.io.File
+
+/**
+ * `data/` 配下の各サブフォルダへのパスを一元化するヘルパ。
+ *
+ * コマンド実装のあちこちに散らばっていた
+ * `dataFolder.resolve("data").resolve("groups"/"railways"/"stations")`
+ * という重複したリテラルを 1 箇所に集約する。
+ *
+ * アクセサは computed（`get()`）にしており、クラスロード時に
+ * [AdvanceRailway.plugin]（`lateinit`）へ触れないようにしている。
+ */
+object DataPaths {
+    private val dataFolder: File get() = AdvanceRailway.plugin.dataFolder.resolve("data")
+    val groups: File get() = dataFolder.resolve("groups")
+    val railways: File get() = dataFolder.resolve("railways")
+    val stations: File get() = dataFolder.resolve("stations")
+}
+
+/**
+ * [Either] の [Either.Right] を取り出す。[Either.Left] の場合は [msg] で生成した
+ * メッセージを [sender] にリッチメッセージとして送り、`null` を返す。
+ *
+ * 各コマンドで繰り返されていた
+ * `when(val res = XUtils.getXData(id)){ is Either.Left -> { send; return }; is Either.Right -> res.value }`
+ * という定型的なアンラップを 1 行に置き換えるためのヘルパ。呼び出し側は
+ * `?: return` で早期リターンする想定。
+ */
+inline fun <L, R> Either<L, R>.getOrSend(sender: CommandSender, msg: (L) -> String): R? = when (this) {
+    is Either.Left -> {
+        sender.sendRichMessage(msg(this.value))
+        null
+    }
+
+    is Either.Right -> this.value
+}

--- a/src/main/kotlin/dev/nikomaru/advancerailway/commands/FileCommand.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/commands/FileCommand.kt
@@ -41,19 +41,19 @@ class FileCommand: KoinComponent {
         }
         val data = when (dataType) {
             DataType.GROUP -> {
-                val file = plugin.dataFolder.resolve("data").resolve("groups").listFiles()!!
+                val file = DataPaths.groups.listFiles() ?: emptyArray()
                 val data = file.map { json.decodeFromString<GroupData>(it.readText()) }
                 stringFormat.encodeToString(data)
             }
 
             DataType.RAILWAY -> {
-                val file = plugin.dataFolder.resolve("data").resolve("railways").listFiles()!!
+                val file = DataPaths.railways.listFiles() ?: emptyArray()
                 val data = file.map { json.decodeFromString<RailwayData>(it.readText()) }
                 stringFormat.encodeToString(data)
             }
 
             DataType.STATION -> {
-                val file = plugin.dataFolder.resolve("data").resolve("stations").listFiles()!!
+                val file = DataPaths.stations.listFiles() ?: emptyArray()
                 val data = file.map { json.decodeFromString<StationData>(it.readText()) }
                 stringFormat.encodeToString(data)
             }
@@ -65,7 +65,12 @@ class FileCommand: KoinComponent {
 
     @Subcommand("import")
     fun import(sender: CommandSender, dataType: DataType, fileName: String) {
-        val data = plugin.dataFolder.resolve("import").resolve(fileName).readText()
+        val importFile = plugin.dataFolder.resolve("import").resolve(fileName)
+        if (!importFile.exists()) {
+            sender.sendRichMessage("Error: Import file not found: $fileName")
+            return
+        }
+        val data = importFile.readText()
         val extension = fileName.split(".").last()
         val stringFormat = when (extension) {
             "csv" -> csv
@@ -74,29 +79,29 @@ class FileCommand: KoinComponent {
         }
         when (dataType) {
             DataType.GROUP -> {
-                val fileDir = plugin.dataFolder.resolve("data").resolve("groups")
+                val fileDir = DataPaths.groups
                 fileDir.listFiles()?.forEach { it.delete() }
                 fileDir.mkdirs()
                 val groupData = stringFormat.decodeFromString<List<GroupData>>(data)
                 groupData.forEach {
-                    val file = plugin.dataFolder.resolve("data").resolve("groups").resolve("${it.groupId.value}.json")
+                    val file = fileDir.resolve("${it.groupId.value}.json")
                     file.writeText(json.encodeToString(it))
                 }
             }
 
             DataType.RAILWAY -> {
-                val fileDir = plugin.dataFolder.resolve("data").resolve("railways")
+                val fileDir = DataPaths.railways
                 fileDir.listFiles()?.forEach { it.delete() }
                 fileDir.mkdirs()
                 val railwayData = stringFormat.decodeFromString<List<RailwayData>>(data)
                 railwayData.forEach {
-                    val file = plugin.dataFolder.resolve("data").resolve("railways").resolve("${it.id.value}.json")
+                    val file = fileDir.resolve("${it.id.value}.json")
                     file.writeText(json.encodeToString(it))
                 }
             }
 
             DataType.STATION -> {
-                val fileDir = plugin.dataFolder.resolve("data").resolve("stations")
+                val fileDir = DataPaths.stations
                 fileDir.listFiles()?.forEach { it.delete() }
                 fileDir.mkdirs()
                 val stationData = stringFormat.decodeFromString<List<StationData>>(data)

--- a/src/main/kotlin/dev/nikomaru/advancerailway/commands/group/GroupEditCommand.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/commands/group/GroupEditCommand.kt
@@ -9,7 +9,7 @@
 
 package dev.nikomaru.advancerailway.commands.group
 
-import arrow.core.Either
+import dev.nikomaru.advancerailway.commands.getOrSend
 import dev.nikomaru.advancerailway.file.value.GroupId
 import dev.nikomaru.advancerailway.utils.GroupUtils
 import org.bukkit.command.CommandSender
@@ -19,36 +19,22 @@ import revxrsal.commands.bukkit.annotation.CommandPermission
 import java.awt.Color
 
 @Command("ar group", "advancerailway group")
-@CommandPermission("advancerailway.command.group")
+@CommandPermission("advancerailway.command.group.write")
 class GroupEditCommand {
     @Subcommand("set name")
     suspend fun setName(sender: CommandSender, groupId: GroupId, newName: String) {
-        val data = when (val res = GroupUtils.getGroupData(groupId)) {
-            is Either.Left -> {
-                sender.sendRichMessage("Station not found")
-                return
-            }
-
-            is Either.Right -> {
-                res.value
-            }
-        }
+        val data = GroupUtils.getGroupData(groupId).getOrSend(sender) { "Group not found" } ?: return
         data.copy(name = newName).save()
         sender.sendRichMessage("Station name set")
     }
 
     @Subcommand("set color")
     suspend fun setColor(sender: CommandSender, groupId: GroupId, r: Int, g: Int, b: Int) {
-        val data = when (val res = GroupUtils.getGroupData(groupId)) {
-            is Either.Left -> {
-                sender.sendRichMessage("Station not found")
-                return
-            }
-
-            is Either.Right -> {
-                res.value
-            }
+        if (r !in 0..255 || g !in 0..255 || b !in 0..255) {
+            sender.sendRichMessage("Error: RGB values must each be between 0 and 255")
+            return
         }
+        val data = GroupUtils.getGroupData(groupId).getOrSend(sender) { "Group not found" } ?: return
         val color = Color(r, g, b)
         data.copy(railwayColor = color).save()
         sender.sendRichMessage("group color set")

--- a/src/main/kotlin/dev/nikomaru/advancerailway/commands/group/GroupInfoCommand.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/commands/group/GroupInfoCommand.kt
@@ -9,8 +9,9 @@
 
 package dev.nikomaru.advancerailway.commands.group
 
-import arrow.core.Either
 import dev.nikomaru.advancerailway.AdvanceRailway
+import dev.nikomaru.advancerailway.commands.DataPaths
+import dev.nikomaru.advancerailway.commands.getOrSend
 import dev.nikomaru.advancerailway.file.value.GroupId
 import dev.nikomaru.advancerailway.utils.GroupUtils
 import org.bukkit.command.CommandSender
@@ -21,20 +22,13 @@ import revxrsal.commands.annotation.Subcommand
 import revxrsal.commands.bukkit.annotation.CommandPermission
 
 @Command("ar group", "advancerailway group")
-@CommandPermission("advancerailway.command.group")
+@CommandPermission("advancerailway.command.group.read")
 class GroupInfoCommand: KoinComponent {
     val plugin: AdvanceRailway by inject()
 
     @Subcommand("info")
     suspend fun info(sender: CommandSender, groupId: GroupId) {
-        val data = when (val result = GroupUtils.getGroupData(groupId)) {
-            is Either.Left -> {
-                sender.sendRichMessage("Group not found")
-                return
-            }
-
-            is Either.Right -> result.value
-        }
+        val data = GroupUtils.getGroupData(groupId).getOrSend(sender) { "Group not found" } ?: return
         sender.sendRichMessage("Group Info: <yellow>${data.groupId.value}")
         sender.sendRichMessage("<yellow>Display Name: <reset>${data.name}")
         sender.sendRichMessage("<yellow>Color: <reset>${data.railwayColor}")
@@ -43,7 +37,7 @@ class GroupInfoCommand: KoinComponent {
     @Subcommand("list")
     fun list(sender: CommandSender) {
         val list =
-            plugin.dataFolder.resolve("data").resolve("groups").listFiles()?.map { it.nameWithoutExtension } ?: run {
+            DataPaths.groups.listFiles()?.map { it.nameWithoutExtension } ?: run {
                 sender.sendRichMessage("No group found")
                 return
             }

--- a/src/main/kotlin/dev/nikomaru/advancerailway/commands/group/GroupMainCommand.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/commands/group/GroupMainCommand.kt
@@ -10,10 +10,14 @@
 package dev.nikomaru.advancerailway.commands.group
 
 import dev.nikomaru.advancerailway.AdvanceRailway
+import dev.nikomaru.advancerailway.commands.DataPaths
 import dev.nikomaru.advancerailway.file.FileLoader
 import dev.nikomaru.advancerailway.file.data.GroupData
+import dev.nikomaru.advancerailway.file.data.RailwayData
 import dev.nikomaru.advancerailway.file.value.GroupId
-import dev.nikomaru.advancerailway.file.value.StationId
+import dev.nikomaru.advancerailway.file.value.IdValidation
+import dev.nikomaru.advancerailway.utils.Utils.json
+import kotlinx.serialization.decodeFromString
 import org.bukkit.command.CommandSender
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
@@ -23,14 +27,14 @@ import revxrsal.commands.bukkit.annotation.CommandPermission
 import java.awt.Color
 
 @Command("ar group", "advancerailway group")
-@CommandPermission("advancerailway.command.group")
+@CommandPermission("advancerailway.command.group.write")
 class GroupMainCommand: KoinComponent {
     val plugin: AdvanceRailway by inject()
 
     @Subcommand("add")
     fun add(sender: CommandSender, id: String, name: String) {
-        id.matches(Regex("[a-zA-Z0-9_-]+")) || run {
-            sender.sendRichMessage("Error: Invalid group ID \"[a-zA-Z0-9_-]+\"")
+        if (!IdValidation.isValid(id)) {
+            sender.sendRichMessage("Error: Invalid group ID \"$id\"")
             return
         }
         val groupId = GroupId(id)
@@ -40,10 +44,20 @@ class GroupMainCommand: KoinComponent {
     }
 
     @Subcommand("remove")
-    suspend fun remove(sender: CommandSender, id: StationId) {
-        val file = plugin.dataFolder.resolve("data").resolve("groups").resolve("${id.value}.json")
+    suspend fun remove(sender: CommandSender, id: GroupId) {
+        val file = DataPaths.groups.resolve("${id.value}.json")
         if (!file.exists()) {
             sender.sendRichMessage("Group not found")
+            return
+        }
+        val dependents = (DataPaths.railways.listFiles() ?: emptyArray()).mapNotNull { railwayFile ->
+            runCatching { json.decodeFromString<RailwayData>(railwayFile.readText()) }.getOrNull()
+        }.filter { it.group == id }.map { it.id.value }
+        if (dependents.isNotEmpty()) {
+            sender.sendRichMessage(
+                "Error: Cannot remove group <yellow>${id.value}</yellow>; " +
+                    "referenced by railway(s): ${dependents.joinToString(", ")}"
+            )
             return
         }
         file.delete()

--- a/src/main/kotlin/dev/nikomaru/advancerailway/commands/railway/RailwayEditCommand.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/commands/railway/RailwayEditCommand.kt
@@ -9,8 +9,8 @@
 
 package dev.nikomaru.advancerailway.commands.railway
 
-import arrow.core.Either
 import dev.nikomaru.advancerailway.AdvanceRailway
+import dev.nikomaru.advancerailway.commands.getOrSend
 import dev.nikomaru.advancerailway.file.type.LineType
 import dev.nikomaru.advancerailway.file.value.GroupId
 import dev.nikomaru.advancerailway.file.value.RailwayId
@@ -24,70 +24,34 @@ import revxrsal.commands.annotation.Subcommand
 import revxrsal.commands.bukkit.annotation.CommandPermission
 
 @Command("ar railway", "advancerailway railway")
-@CommandPermission("advancerailway.command.railway")
+@CommandPermission("advancerailway.command.railway.write")
 class RailwayEditCommand: KoinComponent {
     val plugin: AdvanceRailway by inject()
 
     @Subcommand("set line-type")
     suspend fun setLineType(sender: CommandSender, railwayId: RailwayId, lineType: LineType) {
-        val data = when (val res = RailwayUtils.getRailwayData(railwayId)) {
-            is Either.Left -> {
-                sender.sendRichMessage("Railway not found")
-                return
-            }
-
-            is Either.Right -> {
-                res.value
-            }
-        }
+        val data = RailwayUtils.getRailwayData(railwayId).getOrSend(sender) { "Railway not found" } ?: return
         data.copy(lineType = lineType).save()
         sender.sendRichMessage("Line type set to $lineType")
     }
 
     @Subcommand("set group")
     suspend fun setGroup(sender: CommandSender, railwayId: RailwayId, groupId: GroupId) {
-        val data = when (val res = RailwayUtils.getRailwayData(railwayId)) {
-            is Either.Left -> {
-                sender.sendRichMessage("Railway not found")
-                return
-            }
-
-            is Either.Right -> {
-                res.value
-            }
-        }
+        val data = RailwayUtils.getRailwayData(railwayId).getOrSend(sender) { "Railway not found" } ?: return
         data.copy(group = groupId).save()
         sender.sendRichMessage("Group set to $groupId")
     }
 
     @Subcommand("unset group")
     suspend fun unsetGroup(sender: CommandSender, railwayId: RailwayId) {
-        val data = when (val res = RailwayUtils.getRailwayData(railwayId)) {
-            is Either.Left -> {
-                sender.sendRichMessage("Railway not found")
-                return
-            }
-
-            is Either.Right -> {
-                res.value
-            }
-        }
+        val data = RailwayUtils.getRailwayData(railwayId).getOrSend(sender) { "Railway not found" } ?: return
         data.copy(group = null).save()
         sender.sendRichMessage("Group unset")
     }
 
     @Subcommand("set from-station")
     suspend fun setFromStation(sender: CommandSender, railwayId: RailwayId, stationId: StationId) {
-        val data = when (val res = RailwayUtils.getRailwayData(railwayId)) {
-            is Either.Left -> {
-                sender.sendRichMessage("Railway not found")
-                return
-            }
-
-            is Either.Right -> {
-                res.value
-            }
-        }
+        val data = RailwayUtils.getRailwayData(railwayId).getOrSend(sender) { "Railway not found" } ?: return
         data.copy(fromStation = stationId).save()
         sender.sendRichMessage("From station set to $stationId")
 
@@ -95,16 +59,7 @@ class RailwayEditCommand: KoinComponent {
 
     @Subcommand("set to-station")
     suspend fun setToStation(sender: CommandSender, railwayId: RailwayId, stationId: StationId) {
-        val data = when (val res = RailwayUtils.getRailwayData(railwayId)) {
-            is Either.Left -> {
-                sender.sendRichMessage("Railway not found")
-                return
-            }
-
-            is Either.Right -> {
-                res.value
-            }
-        }
+        val data = RailwayUtils.getRailwayData(railwayId).getOrSend(sender) { "Railway not found" } ?: return
         data.copy(toStation = stationId).save()
         sender.sendRichMessage("To station set to $stationId")
 

--- a/src/main/kotlin/dev/nikomaru/advancerailway/commands/railway/RailwayInfoCommand.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/commands/railway/RailwayInfoCommand.kt
@@ -9,8 +9,9 @@
 
 package dev.nikomaru.advancerailway.commands.railway
 
-import arrow.core.Either
 import dev.nikomaru.advancerailway.AdvanceRailway
+import dev.nikomaru.advancerailway.commands.DataPaths
+import dev.nikomaru.advancerailway.commands.getOrSend
 import dev.nikomaru.advancerailway.file.value.RailwayId
 import dev.nikomaru.advancerailway.utils.RailwayUtils
 import org.bukkit.command.CommandSender
@@ -22,20 +23,13 @@ import revxrsal.commands.bukkit.annotation.CommandPermission
 import kotlin.math.ceil
 
 @Command("ar railway", "advancerailway railway")
-@CommandPermission("advancerailway.command.railway")
+@CommandPermission("advancerailway.command.railway.read")
 class RailwayInfoCommand: KoinComponent {
     val plugin: AdvanceRailway by inject()
 
     @Subcommand("info")
     suspend fun info(sender: CommandSender, railwayId: RailwayId) {
-        val data = when (val result = RailwayUtils.getRailwayData(railwayId)) {
-            is Either.Left -> {
-                sender.sendRichMessage("Railway not found")
-                return
-            }
-
-            is Either.Right -> result.value
-        }
+        val data = RailwayUtils.getRailwayData(railwayId).getOrSend(sender) { "Railway not found" } ?: return
         sender.sendRichMessage("Railway ID: ${data.id.value}")
         sender.sendRichMessage("Railway Stations: ${data.toStation} -> ${data.fromStation}")
         sender.sendRichMessage("Railway Length: ${ceil(data.timeRequired / 6.0) / 10} minutes")
@@ -43,7 +37,7 @@ class RailwayInfoCommand: KoinComponent {
 
     @Subcommand("list")
     fun list(sender: CommandSender) {
-        val list = plugin.dataFolder.resolve("data").resolve("railways").listFiles()?.map { it.nameWithoutExtension }
+        val list = DataPaths.railways.listFiles()?.map { it.nameWithoutExtension }
             ?: run {
                 sender.sendRichMessage("No railway found")
                 return

--- a/src/main/kotlin/dev/nikomaru/advancerailway/commands/railway/RailwayMainCommand.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/commands/railway/RailwayMainCommand.kt
@@ -12,9 +12,11 @@ package dev.nikomaru.advancerailway.commands.railway
 
 import dev.nikomaru.advancerailway.AdvanceRailway
 import dev.nikomaru.advancerailway.Point3D
+import dev.nikomaru.advancerailway.commands.DataPaths
 import dev.nikomaru.advancerailway.file.FileLoader
 import dev.nikomaru.advancerailway.file.data.RailwayData
 import dev.nikomaru.advancerailway.file.type.LineType
+import dev.nikomaru.advancerailway.file.value.IdValidation
 import dev.nikomaru.advancerailway.file.value.RailwayId
 import dev.nikomaru.advancerailway.utils.RailwayUtils
 import dev.nikomaru.advancerailway.utils.StationUtils
@@ -28,7 +30,7 @@ import revxrsal.commands.annotation.Subcommand
 import revxrsal.commands.bukkit.annotation.CommandPermission
 
 @Command("advancerailway railway", "ar railway")
-@CommandPermission("advancerailway.command.railway")
+@CommandPermission("advancerailway.command.railway.write")
 class RailwayMainCommand: KoinComponent {
     val plugin: AdvanceRailway by inject()
 
@@ -36,8 +38,8 @@ class RailwayMainCommand: KoinComponent {
     suspend fun register(
         sender: CommandSender, railwayId: String, startPoint: Point3D, directionPoint: Point3D, endPoint: Point3D
     ) {
-        railwayId.matches(Regex("[a-zA-Z0-9_-]+")) || run {
-            sender.sendRichMessage("Error: Invalid railway ID \"[a-zA-Z0-9_-]+\"")
+        if (!IdValidation.isValid(railwayId)) {
+            sender.sendRichMessage("Error: Invalid railway ID \"$railwayId\"")
             return
         }
         sender.sendRichMessage("Registering railway...")
@@ -48,6 +50,10 @@ class RailwayMainCommand: KoinComponent {
     suspend fun update(
         sender: CommandSender, railwayId: String, startPoint: Point3D, directionPoint: Point3D, endPoint: Point3D
     ) {
+        if (!IdValidation.isValid(railwayId)) {
+            sender.sendRichMessage("Error: Invalid railway ID \"$railwayId\"")
+            return
+        }
         sender.sendRichMessage("Updating railway...")
         handleRailway(sender, railwayId, startPoint, directionPoint, endPoint, "Updated")
     }
@@ -91,7 +97,7 @@ class RailwayMainCommand: KoinComponent {
 
     @Subcommand("remove")
     suspend fun remove(sender: CommandSender, railwayId: RailwayId) {
-        val file = plugin.dataFolder.resolve("data").resolve("railways").resolve("$railwayId.json")
+        val file = DataPaths.railways.resolve("$railwayId.json")
         if (!file.exists()) {
             sender.sendRichMessage("Error: Railway not found")
             return

--- a/src/main/kotlin/dev/nikomaru/advancerailway/commands/station/StationEditCommand.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/commands/station/StationEditCommand.kt
@@ -9,8 +9,8 @@
 
 package dev.nikomaru.advancerailway.commands.station
 
-import arrow.core.Either
 import dev.nikomaru.advancerailway.Point3D
+import dev.nikomaru.advancerailway.commands.getOrSend
 import dev.nikomaru.advancerailway.file.value.StationId
 import dev.nikomaru.advancerailway.utils.StationUtils
 import dev.nikomaru.advancerailway.utils.Utils.toPoint3D
@@ -23,20 +23,11 @@ import revxrsal.commands.bukkit.annotation.CommandPermission
 import java.awt.Color
 
 @Command("ar station", "advancerailway station")
-@CommandPermission("advancerailway.command.station")
+@CommandPermission("advancerailway.command.station.write")
 class StationEditCommand {
     @Subcommand("set name")
     suspend fun setName(sender: CommandSender, stationId: StationId, newName: String) {
-        val data = when (val res = StationUtils.getStationData(stationId)) {
-            is Either.Left -> {
-                sender.sendRichMessage("Station not found")
-                return
-            }
-
-            is Either.Right -> {
-                res.value
-            }
-        }
+        val data = StationUtils.getStationData(stationId).getOrSend(sender) { "Station not found" } ?: return
         data.copy(name = newName).save()
         sender.sendRichMessage("Station name set")
     }
@@ -44,53 +35,37 @@ class StationEditCommand {
     @Subcommand("set location")
     suspend fun setLocation(sender: CommandSender, stationId: StationId, inputPoint: Point3D?) {
         if (sender !is Player && inputPoint == null) {
-            println("You must enter the point")
+            sender.sendRichMessage("Error: You must enter the point")
             return
         }
         val point = inputPoint ?: (sender as Player).location.toPoint3D()
-        val world = if (sender is Player) sender.world else Bukkit.getWorld("world")!!
-        val data = when (val res = StationUtils.getStationData(stationId)) {
-            is Either.Left -> {
-                sender.sendRichMessage("Station not found")
+        val world = if (sender is Player) {
+            sender.world
+        } else {
+            Bukkit.getWorld("world") ?: run {
+                sender.sendRichMessage("Error: World \"world\" not found")
                 return
             }
-
-            is Either.Right -> {
-                res.value
-            }
         }
+        val data = StationUtils.getStationData(stationId).getOrSend(sender) { "Station not found" } ?: return
         data.copy(point = point, world = world).save()
         sender.sendRichMessage("Station location set")
     }
 
     @Subcommand("set numbering")
     suspend fun setNumbering(sender: CommandSender, stationId: StationId, numbering: String) {
-        val data = when (val res = StationUtils.getStationData(stationId)) {
-            is Either.Left -> {
-                sender.sendRichMessage("Station not found")
-                return
-            }
-
-            is Either.Right -> {
-                res.value
-            }
-        }
+        val data = StationUtils.getStationData(stationId).getOrSend(sender) { "Station not found" } ?: return
         data.copy(numbering = numbering).save()
         sender.sendRichMessage("Station numbering set")
     }
 
     @Subcommand("set color")
     suspend fun setColor(sender: CommandSender, stationId: StationId, r: Int, g: Int, b: Int) {
-        val data = when (val res = StationUtils.getStationData(stationId)) {
-            is Either.Left -> {
-                sender.sendRichMessage("Station not found")
-                return
-            }
-
-            is Either.Right -> {
-                res.value
-            }
+        if (r !in 0..255 || g !in 0..255 || b !in 0..255) {
+            sender.sendRichMessage("Error: RGB values must each be between 0 and 255")
+            return
         }
+        val data = StationUtils.getStationData(stationId).getOrSend(sender) { "Station not found" } ?: return
         data.copy(color = Color(r, g, b)).save()
         sender.sendRichMessage("Station color set")
     }

--- a/src/main/kotlin/dev/nikomaru/advancerailway/commands/station/StationInfoCommand.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/commands/station/StationInfoCommand.kt
@@ -9,8 +9,9 @@
 
 package dev.nikomaru.advancerailway.commands.station
 
-import arrow.core.Either
 import dev.nikomaru.advancerailway.AdvanceRailway
+import dev.nikomaru.advancerailway.commands.DataPaths
+import dev.nikomaru.advancerailway.commands.getOrSend
 import dev.nikomaru.advancerailway.file.value.StationId
 import dev.nikomaru.advancerailway.utils.StationUtils
 import org.bukkit.command.CommandSender
@@ -21,22 +22,13 @@ import revxrsal.commands.annotation.Subcommand
 import revxrsal.commands.bukkit.annotation.CommandPermission
 
 @Command("ar station", "advancerailway station")
-@CommandPermission("advancerailway.command.station")
+@CommandPermission("advancerailway.command.station.read")
 class StationInfoCommand: KoinComponent {
     val plugin: AdvanceRailway by inject()
 
     @Subcommand("info")
     suspend fun info(sender: CommandSender, stationId: StationId) {
-        val data = when (val res = StationUtils.getStationData(stationId)) {
-            is Either.Left -> {
-                sender.sendRichMessage("Station not found")
-                return
-            }
-
-            is Either.Right -> {
-                res.value
-            }
-        }
+        val data = StationUtils.getStationData(stationId).getOrSend(sender) { "Station not found" } ?: return
         sender.sendRichMessage("Station ID: ${data.stationId.value}")
         sender.sendRichMessage("Station Name: ${data.name} <click:suggest_command:'/ar station rename ${data.stationId.value} <newName>'>[edit]</click>")
         sender.sendRichMessage("Station Location: ${data.world.name}:${data.point} <click:suggest_command:'/ar station set location ${data.stationId.value} <newName>'>[edit]</click>")
@@ -47,7 +39,7 @@ class StationInfoCommand: KoinComponent {
     @Subcommand("list")
     fun list(sender: CommandSender) {
         val list =
-            plugin.dataFolder.resolve("data").resolve("stations").listFiles()?.map { it.nameWithoutExtension } ?: run {
+            DataPaths.stations.listFiles()?.map { it.nameWithoutExtension } ?: run {
                 sender.sendRichMessage("No station found")
                 return
             }

--- a/src/main/kotlin/dev/nikomaru/advancerailway/commands/station/StationMainCommand.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/commands/station/StationMainCommand.kt
@@ -11,10 +11,15 @@ package dev.nikomaru.advancerailway.commands.station
 
 import dev.nikomaru.advancerailway.AdvanceRailway
 import dev.nikomaru.advancerailway.Point3D
+import dev.nikomaru.advancerailway.commands.DataPaths
 import dev.nikomaru.advancerailway.file.FileLoader
+import dev.nikomaru.advancerailway.file.data.RailwayData
 import dev.nikomaru.advancerailway.file.data.StationData
+import dev.nikomaru.advancerailway.file.value.IdValidation
 import dev.nikomaru.advancerailway.file.value.StationId
+import dev.nikomaru.advancerailway.utils.Utils.json
 import dev.nikomaru.advancerailway.utils.Utils.toPoint3D
+import kotlinx.serialization.decodeFromString
 import org.bukkit.Bukkit
 import org.bukkit.command.CommandSender
 import org.bukkit.entity.Player
@@ -26,7 +31,7 @@ import revxrsal.commands.annotation.Subcommand
 import revxrsal.commands.bukkit.annotation.CommandPermission
 
 @Command("ar station", "advancerailway station")
-@CommandPermission("advancerailway.command.station")
+@CommandPermission("advancerailway.command.station.write")
 class StationMainCommand: KoinComponent {
     val plugin: AdvanceRailway by inject()
 
@@ -35,15 +40,22 @@ class StationMainCommand: KoinComponent {
         sender: CommandSender, id: String, name: String, @Optional inputPoint: Point3D? = null
     ) { // Add station
         if (sender !is Player && inputPoint == null) {
-            println("You must enter the point")
+            sender.sendRichMessage("Error: You must enter the point")
             return
         }
-        id.matches(Regex("[a-zA-Z0-9_-]+")) || run {
-            sender.sendRichMessage("Error: Invalid station ID \"[a-zA-Z0-9_-]+\"")
+        if (!IdValidation.isValid(id)) {
+            sender.sendRichMessage("Error: Invalid station ID \"$id\"")
             return
         }
         val point = inputPoint ?: (sender as Player).location.toPoint3D()
-        val world = if (sender is Player) sender.world else Bukkit.getWorld("world")!!
+        val world = if (sender is Player) {
+            sender.world
+        } else {
+            Bukkit.getWorld("world") ?: run {
+                sender.sendRichMessage("Error: World \"world\" not found")
+                return
+            }
+        }
         val stationId = StationId(id)
         val data = StationData(stationId, name, null, world, point, null)
         data.save()
@@ -52,9 +64,19 @@ class StationMainCommand: KoinComponent {
 
     @Subcommand("remove")
     suspend fun remove(sender: CommandSender, id: StationId) { // Remove station
-        val file = plugin.dataFolder.resolve("data").resolve("stations").resolve("${id.value}.json")
+        val file = DataPaths.stations.resolve("${id.value}.json")
         if (!file.exists()) {
             sender.sendRichMessage("Station not found")
+            return
+        }
+        val dependents = (DataPaths.railways.listFiles() ?: emptyArray()).mapNotNull { railwayFile ->
+            runCatching { json.decodeFromString<RailwayData>(railwayFile.readText()) }.getOrNull()
+        }.filter { it.fromStation == id || it.toStation == id }.map { it.id.value }
+        if (dependents.isNotEmpty()) {
+            sender.sendRichMessage(
+                "Error: Cannot remove station <yellow>${id.value}</yellow>; " +
+                    "referenced by railway(s): ${dependents.joinToString(", ")}"
+            )
             return
         }
         file.delete()

--- a/src/main/kotlin/dev/nikomaru/advancerailway/error/DataSearchError.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/error/DataSearchError.kt
@@ -10,5 +10,6 @@
 package dev.nikomaru.advancerailway.error
 
 enum class DataSearchError {
-    NOT_FOUND
+    NOT_FOUND,
+    DESERIALIZATION_FAILED
 }

--- a/src/main/kotlin/dev/nikomaru/advancerailway/file/FileLoader.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/file/FileLoader.kt
@@ -13,6 +13,8 @@ import dev.nikomaru.advancerailway.AdvanceRailway
 import dev.nikomaru.advancerailway.file.loader.ConfigDataLoader
 import dev.nikomaru.advancerailway.file.loader.RailwayDataLoader
 import dev.nikomaru.advancerailway.file.loader.StationDataLoader
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import xyz.jpenilla.squaremap.api.SimpleLayerProvider
@@ -20,7 +22,15 @@ import xyz.jpenilla.squaremap.api.SimpleLayerProvider
 object FileLoader: KoinComponent {
     private val provider: SimpleLayerProvider by inject()
     private val plugin: AdvanceRailway by inject()
-    suspend fun load() {
+
+    /**
+     * マーカーの全消去→再構築を直列化するためのロック。
+     * 複数の保存処理が並行して [mapDataLoad] を呼んでも、
+     * clearMarkers() と addMarker() が交錯して不整合な状態にならないようにする。
+     */
+    private val mapLoadMutex = Mutex()
+
+    suspend fun load() = mapLoadMutex.withLock {
         val importFolder = plugin.dataFolder.resolve("import")
         if (!importFolder.exists()) {
             importFolder.mkdirs()
@@ -32,7 +42,7 @@ object FileLoader: KoinComponent {
         RailwayDataLoader().load()
     }
 
-    suspend fun mapDataLoad() {
+    suspend fun mapDataLoad() = mapLoadMutex.withLock {
         provider.clearMarkers()
         StationDataLoader().load()
         RailwayDataLoader().load()

--- a/src/main/kotlin/dev/nikomaru/advancerailway/file/data/ConfigData.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/file/data/ConfigData.kt
@@ -18,4 +18,10 @@ data class ConfigData(
     val circleMax: Double = 20.0,
     val circleMultiple: Double = 5.0, // size = base + (multiple * (stations.size))
     val calcString: String = "base + (multiple * (stations.size))", //TODO: Implement this
+    /**
+     * MineAuth の HTTP API 連携を有効にするか。
+     * false の場合、MineAuth が導入されていてもエンドポイントを登録しない。
+     * 有効時もエンドポイントは権限（advancerailway.mineauth.read）で保護される。
+     */
+    val mineAuthEnabled: Boolean = true,
 )

--- a/src/main/kotlin/dev/nikomaru/advancerailway/file/data/GroupData.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/file/data/GroupData.kt
@@ -12,6 +12,7 @@ package dev.nikomaru.advancerailway.file.data
 import dev.nikomaru.advancerailway.AdvanceRailway
 import dev.nikomaru.advancerailway.AdvanceRailway.Companion.plugin
 import dev.nikomaru.advancerailway.file.utils.ColorSerializer
+import dev.nikomaru.advancerailway.file.utils.writeAtomically
 import dev.nikomaru.advancerailway.file.value.GroupId
 import dev.nikomaru.advancerailway.utils.Utils.json
 import kotlinx.serialization.Serializable
@@ -29,7 +30,7 @@ data class GroupData(
     val plugin: AdvanceRailway by inject()
     fun save() {
         val file = plugin.dataFolder.resolve("data").resolve("groups").resolve("${groupId.value}.json")
-        file.writeText(json.encodeToString(this))
+        writeAtomically(file, json.encodeToString(this))
     }
 
     companion object {

--- a/src/main/kotlin/dev/nikomaru/advancerailway/file/data/RailwayData.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/file/data/RailwayData.kt
@@ -15,6 +15,7 @@ import dev.nikomaru.advancerailway.Point3D
 import dev.nikomaru.advancerailway.file.FileLoader
 import dev.nikomaru.advancerailway.file.type.LineType
 import dev.nikomaru.advancerailway.file.utils.WorldSerializer
+import dev.nikomaru.advancerailway.file.utils.writeAtomically
 import dev.nikomaru.advancerailway.file.value.GroupId
 import dev.nikomaru.advancerailway.file.value.RailwayId
 import dev.nikomaru.advancerailway.file.value.StationId
@@ -41,7 +42,7 @@ data class RailwayData(
 
     suspend fun save() {
         val file = plugin.dataFolder.resolve("data").resolve("railways").resolve("${id.value}.json")
-        file.writeText(json.encodeToString(this))
+        writeAtomically(file, json.encodeToString(this))
         FileLoader.mapDataLoad()
     }
 

--- a/src/main/kotlin/dev/nikomaru/advancerailway/file/data/StationData.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/file/data/StationData.kt
@@ -15,6 +15,7 @@ import dev.nikomaru.advancerailway.Point3D
 import dev.nikomaru.advancerailway.file.FileLoader
 import dev.nikomaru.advancerailway.file.utils.ColorSerializer
 import dev.nikomaru.advancerailway.file.utils.WorldSerializer
+import dev.nikomaru.advancerailway.file.utils.writeAtomically
 import dev.nikomaru.advancerailway.file.value.StationId
 import dev.nikomaru.advancerailway.utils.Utils.json
 import kotlinx.serialization.Serializable
@@ -33,21 +34,28 @@ data class StationData(
     val world: @Serializable(with = WorldSerializer::class) World,
     val point: Point3D,
     val overrideSize: Double?,
-    val color: @Serializable(with = ColorSerializer::class) Color = Color(
-        Random.nextInt(256),
-        Random.nextInt(256),
-        Random.nextInt(256)
-    )
+    val color: @Serializable(with = ColorSerializer::class) Color = defaultColor(stationId)
 ): KoinComponent {
     val plugin: AdvanceRailway by inject()
 
     suspend fun save() {
         val file = plugin.dataFolder.resolve("data").resolve("stations").resolve("${stationId.value}.json")
-        file.writeText(json.encodeToString(this))
+        writeAtomically(file, json.encodeToString(this))
         FileLoader.mapDataLoad()
     }
 
     companion object {
+        /**
+         * 駅 ID から決定論的に既定色を導出する。
+         *
+         * 乱数シードを駅 ID に固定することで、`color` を持たない旧データを
+         * デコードするたびに色が変わってしまう問題を防ぐ。
+         */
+        fun defaultColor(stationId: StationId): Color {
+            val random = Random(stationId.hashCode().toLong())
+            return Color(random.nextInt(256), random.nextInt(256), random.nextInt(256))
+        }
+
         fun load(stationId: StationId): StationData {
             val file = plugin.dataFolder.resolve("data").resolve("stations").resolve("${stationId.value}.json")
             return json.decodeFromString(file.readText())

--- a/src/main/kotlin/dev/nikomaru/advancerailway/file/loader/ConfigDataLoader.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/file/loader/ConfigDataLoader.kt
@@ -11,6 +11,7 @@ package dev.nikomaru.advancerailway.file.loader
 
 import dev.nikomaru.advancerailway.AdvanceRailway
 import dev.nikomaru.advancerailway.file.data.ConfigData
+import dev.nikomaru.advancerailway.file.utils.writeAtomically
 import dev.nikomaru.advancerailway.utils.Utils.json
 import kotlinx.serialization.encodeToString
 import org.koin.core.component.KoinComponent
@@ -25,10 +26,9 @@ class ConfigDataLoader: KoinComponent {
         val file = plugin.dataFolder.resolve("config.json")
         if (!file.exists()) {
             file.parentFile.mkdirs()
-            file.createNewFile()
             val data = ConfigData(1000)
             val str = json.encodeToString(data)
-            file.writeText(str)
+            writeAtomically(file, str)
         }
         val configData = json.decodeFromString<ConfigData>(file.readText())
         loadKoinModules(module {

--- a/src/main/kotlin/dev/nikomaru/advancerailway/file/loader/RailwayDataLoader.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/file/loader/RailwayDataLoader.kt
@@ -39,7 +39,12 @@ class RailwayDataLoader: KoinComponent {
             groupDataFolder.mkdirs()
         }
         railwayDataFolder.listFiles()?.forEach { file ->
-            val data = json.decodeFromString<RailwayData>(file.readText())
+            val data = try {
+                json.decodeFromString<RailwayData>(file.readText())
+            } catch (e: Exception) {
+                plugin.logger.warning("Skipping malformed railway data file '${file.name}': ${e.message}")
+                return@forEach
+            }
             val key = Key.of(data.id.value)
             val marker = Marker.multiPolyline(data.line.points.map { Point.of(it.x, it.z) })
             val arrow = when (data.lineType) {

--- a/src/main/kotlin/dev/nikomaru/advancerailway/file/loader/StationDataLoader.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/file/loader/StationDataLoader.kt
@@ -40,13 +40,23 @@ class StationDataLoader: KoinComponent {
             railwayDataFolder.mkdirs()
         }
         railwayDataFolder.listFiles()?.forEach { file ->
-            val data = json.decodeFromString<RailwayData>(file.readText())
+            val data = try {
+                json.decodeFromString<RailwayData>(file.readText())
+            } catch (e: Exception) {
+                plugin.logger.warning("Skipping malformed railway data file '${file.name}': ${e.message}")
+                return@forEach
+            }
             joinedCount[data.toStation] = joinedCount.getOrDefault(data.toStation, 0) + 1
             joinedCount[data.fromStation] = joinedCount.getOrDefault(data.fromStation, 0) + 1
         }
 
         stationDataFolder.listFiles()?.forEach { file ->
-            val stationData = json.decodeFromString<StationData>(file.readText())
+            val stationData = try {
+                json.decodeFromString<StationData>(file.readText())
+            } catch (e: Exception) {
+                plugin.logger.warning("Skipping malformed station data file '${file.name}': ${e.message}")
+                return@forEach
+            }
             val key = Key.of(stationData.stationId.value)
             val color = stationData.color
             val colorOption = MarkerOptions.builder().fillColor(color.brighter()).strokeColor(color).clickTooltip(

--- a/src/main/kotlin/dev/nikomaru/advancerailway/file/utils/AtomicFile.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/file/utils/AtomicFile.kt
@@ -1,0 +1,45 @@
+/*
+ * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ *
+ * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication along with this software.
+ * If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+package dev.nikomaru.advancerailway.file.utils
+
+import java.io.File
+import java.nio.file.AtomicMoveNotSupportedException
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+
+/**
+ * [content] を [target] へアトミックに書き込む。
+ *
+ * 一旦同じディレクトリ内の一時ファイルへ書き出してから
+ * [Files.move] でアトミックに置き換えることで、書き込み途中で
+ * クラッシュしても [target] が中途半端な内容で壊れないようにする。
+ * ファイルシステムがアトミック移動に対応していない場合は
+ * [StandardCopyOption.REPLACE_EXISTING] のみでフォールバックする。
+ */
+fun writeAtomically(target: File, content: String) {
+    val parent = target.parentFile
+    parent?.mkdirs()
+    val tmp = File.createTempFile(target.name, ".tmp", parent)
+    try {
+        tmp.writeText(content)
+        try {
+            Files.move(
+                tmp.toPath(),
+                target.toPath(),
+                StandardCopyOption.ATOMIC_MOVE,
+                StandardCopyOption.REPLACE_EXISTING
+            )
+        } catch (_: AtomicMoveNotSupportedException) {
+            Files.move(tmp.toPath(), target.toPath(), StandardCopyOption.REPLACE_EXISTING)
+        }
+    } finally {
+        tmp.delete()
+    }
+}

--- a/src/main/kotlin/dev/nikomaru/advancerailway/file/utils/Serializer.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/file/utils/Serializer.kt
@@ -12,6 +12,7 @@ package dev.nikomaru.advancerailway.file.utils
 import dev.nikomaru.advancerailway.Line3D
 import dev.nikomaru.advancerailway.Point3D
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.encoding.Decoder
@@ -95,7 +96,9 @@ object WorldSerializer: KSerializer<org.bukkit.World> {
     override val descriptor = PrimitiveSerialDescriptor("World", PrimitiveKind.STRING)
 
     override fun deserialize(decoder: Decoder): org.bukkit.World {
-        return Bukkit.getWorld(decoder.decodeString())!!
+        val name = decoder.decodeString()
+        return Bukkit.getWorld(name)
+            ?: throw SerializationException("World not found: \"$name\"")
     }
 
     override fun serialize(encoder: Encoder, value: org.bukkit.World) {

--- a/src/main/kotlin/dev/nikomaru/advancerailway/file/value/GroupId.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/file/value/GroupId.kt
@@ -20,8 +20,25 @@ import kotlinx.serialization.encoding.Encoder
 
 @Serializable(with = GroupNameSerializer::class)
 class GroupId(val value: String) {
+    init {
+        require(IdValidation.isValid(value)) { "Invalid group ID: \"$value\"" }
+    }
+
     suspend fun toData() = GroupUtils.getGroupData(this).getOrNull()
     override fun toString(): String = value
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is GroupId) return false
+
+        if (value != other.value) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return value.hashCode()
+    }
 }
 
 object GroupNameSerializer: KSerializer<GroupId> {

--- a/src/main/kotlin/dev/nikomaru/advancerailway/file/value/IdValidation.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/file/value/IdValidation.kt
@@ -1,0 +1,37 @@
+/*
+ * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ *
+ * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication along with this software.
+ * If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+package dev.nikomaru.advancerailway.file.value
+
+/**
+ * 駅・路線・グループなどの ID フォーマット検証を一元化するためのユーティリティ。
+ *
+ * ID は英数字・アンダースコア・ハイフンのみを許可する allowlist 方式で検証する。
+ * これにより、パストラバーサル（`..`, `/`, `\`, `.`）や NUL バイト、
+ * MiniMessage を破壊する文字などを含む不正な ID を弾く。
+ *
+ * コマンドや HTTP エンドポイントなどの境界では、値クラスを構築する前に
+ * [isValid] を呼び出してユーザ入力を検証すること。値クラスの `init` でも同じ検証を
+ * 行うため、不正な ID での構築は [IllegalArgumentException] を送出する。
+ */
+object IdValidation {
+    /**
+     * ID として許可する文字列の allowlist 正規表現。
+     * 英数字・アンダースコア・ハイフンのみで構成され、1 文字以上であること。
+     */
+    val PATTERN: Regex = Regex("^[A-Za-z0-9_-]+$")
+
+    /**
+     * [id] が [PATTERN] に完全一致するかを判定する。
+     *
+     * 部分一致ではなく完全一致（[Regex.matches]）で判定するため、
+     * 改行を含む文字列などの注入を確実に弾く。
+     */
+    fun isValid(id: String): Boolean = PATTERN.matches(id)
+}

--- a/src/main/kotlin/dev/nikomaru/advancerailway/file/value/RailwayId.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/file/value/RailwayId.kt
@@ -20,8 +20,25 @@ import kotlinx.serialization.encoding.Encoder
 
 @Serializable(with = RailwayNameSerializer::class)
 class RailwayId(val value: String) {
+    init {
+        require(IdValidation.isValid(value)) { "Invalid railway ID: \"$value\"" }
+    }
+
     suspend fun toData() = RailwayUtils.getRailwayData(this).getOrNull()
     override fun toString(): String = value
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is RailwayId) return false
+
+        if (value != other.value) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return value.hashCode()
+    }
 }
 
 object RailwayNameSerializer: KSerializer<RailwayId> {

--- a/src/main/kotlin/dev/nikomaru/advancerailway/file/value/StationId.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/file/value/StationId.kt
@@ -21,6 +21,10 @@ import kotlinx.serialization.encoding.Encoder
 
 @Serializable(with = StationNameSerializer::class)
 class StationId(val value: String) {
+    init {
+        require(IdValidation.isValid(value)) { "Invalid station ID: \"$value\"" }
+    }
+
     suspend fun toData() = StationUtils.getStationData(this).getOrNull()
 
     override fun toString(): String {

--- a/src/main/kotlin/dev/nikomaru/advancerailway/listener/RailClickEvent.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/listener/RailClickEvent.kt
@@ -14,7 +14,7 @@ import dev.nikomaru.advancerailway.Point3D
 import dev.nikomaru.advancerailway.utils.RailwayUtils
 import dev.nikomaru.advancerailway.utils.RailwayUtils.railEndpointInspect
 import dev.nikomaru.advancerailway.utils.StationUtils
-import dev.nikomaru.advancerailway.utils.coroutines.async
+import dev.nikomaru.advancerailway.utils.coroutines.minecraft
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -37,7 +37,7 @@ class RailClickEvent: Listener {
             return
         }
         detect.remove(player)
-        withContext(Dispatchers.async) {
+        withContext(Dispatchers.minecraft) {
             val block = event.clickedBlock ?: return@withContext
             val blockState = block.blockData
             if (blockState !is Rail) {
@@ -71,7 +71,11 @@ class RailClickEvent: Listener {
                             val (start, direction, end) = value
                             val startStation = StationUtils.nearStation(start!!.toLocation(player.world)).getOrNull()
                             val endStation = StationUtils.nearStation(end!!.toLocation(player.world)).getOrNull()
-                            val railwayId = startStation!!.value + "_" + endStation!!.value
+                            if (startStation == null || endStation == null) {
+                                player.sendRichMessage("No stations registered yet")
+                                return@forEach
+                            }
+                            val railwayId = startStation.value + "_" + endStation.value
                             val suggestMessage =
                                 "<click:suggest_command:'/ar railway add $railwayId ${start.toPlainString()} ${direction!!.toPlainString()} ${end.toPlainString()}'>[create]</click>"
                             player.sendRichMessage(

--- a/src/main/kotlin/dev/nikomaru/advancerailway/mineauth/MineAuthIntegration.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/mineauth/MineAuthIntegration.kt
@@ -10,21 +10,34 @@
 package dev.nikomaru.advancerailway.mineauth
 
 import dev.nikomaru.advancerailway.AdvanceRailway
+import dev.nikomaru.advancerailway.file.data.ConfigData
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.get
 import party.morino.mineauth.api.MineAuthAPI
 
 /**
  * MineAuth との連携をセットアップするエントリーポイント。
  * MineAuth は softdepend であり、存在しない場合は何もせず AdvanceRailway は単体で動作する。
  */
-object MineAuthIntegration {
+object MineAuthIntegration : KoinComponent {
 
     /**
      * MineAuth が導入されていれば [RailwayApiHandler] を登録する。
      * 登録後、エンドポイントは `/api/v1/plugins/advancerailway/` 配下で利用可能になる。
      *
+     * ただし [ConfigData.mineAuthEnabled] が false の場合は登録をスキップする（フェイルセーフ）。
+     * 登録した場合でも各エンドポイントは権限で保護される（[RailwayApiHandler] 参照）。
+     *
      * @param plugin AdvanceRailway 本体
      */
     fun register(plugin: AdvanceRailway) {
+        // 設定で連携が無効化されている場合は何もしない。
+        val config = get<ConfigData>()
+        if (!config.mineAuthEnabled) {
+            plugin.logger.info("MineAuth integration disabled by config; skipping HTTP endpoint registration.")
+            return
+        }
+
         // MineAuth 本体を安全にキャストして取得する（未導入・非対応バージョンでは null）。
         val api = plugin.server.pluginManager.getPlugin("MineAuth") as? MineAuthAPI
         if (api == null) {

--- a/src/main/kotlin/dev/nikomaru/advancerailway/mineauth/RailwayApiHandler.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/mineauth/RailwayApiHandler.kt
@@ -14,6 +14,7 @@ import dev.nikomaru.advancerailway.file.data.GroupData
 import dev.nikomaru.advancerailway.file.data.RailwayData
 import dev.nikomaru.advancerailway.file.data.StationData
 import dev.nikomaru.advancerailway.file.value.GroupId
+import dev.nikomaru.advancerailway.file.value.IdValidation
 import dev.nikomaru.advancerailway.file.value.RailwayId
 import dev.nikomaru.advancerailway.file.value.StationId
 import dev.nikomaru.advancerailway.mineauth.dto.GroupDto
@@ -36,6 +37,8 @@ import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import party.morino.mineauth.api.annotations.GetMapping
 import party.morino.mineauth.api.annotations.PathParam
+import party.morino.mineauth.api.annotations.Permission
+import party.morino.mineauth.api.annotations.QueryParams
 import party.morino.mineauth.api.http.HttpError
 import party.morino.mineauth.api.http.HttpStatus
 import java.io.File
@@ -51,13 +54,40 @@ import java.io.File
 class RailwayApiHandler : KoinComponent {
     private val plugin: AdvanceRailway by inject()
 
+    companion object {
+        /** すべての読み取りエンドポイントに要求する権限ノード。 */
+        const val READ_PERMISSION = "advancerailway.mineauth.read"
+
+        /** limit 未指定時に返す件数の既定値。 */
+        const val DEFAULT_LIMIT = 100
+
+        /** limit の上限。過大なリクエストによる全件読み取り・エンコードを防ぐ。 */
+        const val MAX_LIMIT = 500
+    }
+
     /**
-     * すべての駅を取得する。
-     * GET /stations
+     * limit/offset のクエリパラメータを健全な範囲に正規化する。
+     *
+     * - offset: 0 以上（負値・不正値は 0 に丸める）。
+     * - limit: 1..[MAX_LIMIT] の範囲。未指定・不正値は [DEFAULT_LIMIT]。
      */
+    private fun paging(params: Map<String, String>): Pair<Int, Int> {
+        val offset = params["offset"]?.toIntOrNull()?.coerceAtLeast(0) ?: 0
+        val limit = (params["limit"]?.toIntOrNull() ?: DEFAULT_LIMIT).coerceIn(1, MAX_LIMIT)
+        return offset to limit
+    }
+
+    /**
+     * すべての駅を取得する（limit/offset でページングする）。
+     * GET /stations?limit={n}&offset={n}
+     */
+    @Permission(READ_PERMISSION)
     @GetMapping("/stations")
-    suspend fun listStations(): TextContent {
+    suspend fun listStations(@QueryParams params: Map<String, String> = emptyMap()): TextContent {
+        val (offset, limit) = paging(params)
         val stations = listIds("stations")
+            .drop(offset)
+            .take(limit)
             .mapNotNull { StationUtils.getStationData(StationId(it)).getOrNull() }
             .map { it.toDto() }
         return json(StationsResponse(stations), StationsResponse.serializer())
@@ -67,20 +97,26 @@ class RailwayApiHandler : KoinComponent {
      * 指定した駅を取得する。
      * GET /stations/{id}
      */
+    @Permission(READ_PERMISSION)
     @GetMapping("/stations/{id}")
     suspend fun getStation(@PathParam("id") id: String): TextContent {
+        if (!IdValidation.isValid(id)) throw HttpError(HttpStatus.NOT_FOUND, "Station not found: $id")
         val station = StationUtils.getStationData(StationId(id)).getOrNull()
             ?: throw HttpError(HttpStatus.NOT_FOUND, "Station not found: $id")
         return json(station.toDto(), StationDto.serializer())
     }
 
     /**
-     * すべての路線を取得する。
-     * GET /railways
+     * すべての路線を取得する（limit/offset でページングする）。
+     * GET /railways?limit={n}&offset={n}
      */
+    @Permission(READ_PERMISSION)
     @GetMapping("/railways")
-    suspend fun listRailways(): TextContent {
+    suspend fun listRailways(@QueryParams params: Map<String, String> = emptyMap()): TextContent {
+        val (offset, limit) = paging(params)
         val railways = listIds("railways")
+            .drop(offset)
+            .take(limit)
             .mapNotNull { RailwayUtils.getRailwayData(RailwayId(it)).getOrNull() }
             .map { it.toDto() }
         return json(RailwaysResponse(railways), RailwaysResponse.serializer())
@@ -90,20 +126,26 @@ class RailwayApiHandler : KoinComponent {
      * 指定した路線を取得する。
      * GET /railways/{id}
      */
+    @Permission(READ_PERMISSION)
     @GetMapping("/railways/{id}")
     suspend fun getRailway(@PathParam("id") id: String): TextContent {
+        if (!IdValidation.isValid(id)) throw HttpError(HttpStatus.NOT_FOUND, "Railway not found: $id")
         val railway = RailwayUtils.getRailwayData(RailwayId(id)).getOrNull()
             ?: throw HttpError(HttpStatus.NOT_FOUND, "Railway not found: $id")
         return json(railway.toDto(), RailwayDto.serializer())
     }
 
     /**
-     * すべてのグループを取得する。
-     * GET /groups
+     * すべてのグループを取得する（limit/offset でページングする）。
+     * GET /groups?limit={n}&offset={n}
      */
+    @Permission(READ_PERMISSION)
     @GetMapping("/groups")
-    suspend fun listGroups(): TextContent {
+    suspend fun listGroups(@QueryParams params: Map<String, String> = emptyMap()): TextContent {
+        val (offset, limit) = paging(params)
         val groups = listIds("groups")
+            .drop(offset)
+            .take(limit)
             .mapNotNull { GroupUtils.getGroupData(GroupId(it)).getOrNull() }
             .map { it.toDto() }
         return json(GroupsResponse(groups), GroupsResponse.serializer())
@@ -113,8 +155,10 @@ class RailwayApiHandler : KoinComponent {
      * 指定したグループを取得する。
      * GET /groups/{id}
      */
+    @Permission(READ_PERMISSION)
     @GetMapping("/groups/{id}")
     suspend fun getGroup(@PathParam("id") id: String): TextContent {
+        if (!IdValidation.isValid(id)) throw HttpError(HttpStatus.NOT_FOUND, "Group not found: $id")
         val group = GroupUtils.getGroupData(GroupId(id)).getOrNull()
             ?: throw HttpError(HttpStatus.NOT_FOUND, "Group not found: $id")
         return json(group.toDto(), GroupDto.serializer())

--- a/src/main/kotlin/dev/nikomaru/advancerailway/utils/GroupUtils.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/utils/GroupUtils.kt
@@ -32,6 +32,11 @@ object GroupUtils: KoinComponent {
         if (!file.exists()) {
             return@withContext Either.Left(DataSearchError.NOT_FOUND)
         }
-        return@withContext Either.Right(json.decodeFromString(file.readText()))
+        return@withContext try {
+            Either.Right(json.decodeFromString<GroupData>(file.readText()))
+        } catch (e: Exception) {
+            plugin.logger.warning("Failed to decode group data '${file.name}': ${e.message}")
+            Either.Left(DataSearchError.DESERIALIZATION_FAILED)
+        }
     }
 }

--- a/src/main/kotlin/dev/nikomaru/advancerailway/utils/RailwayUtils.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/utils/RailwayUtils.kt
@@ -22,7 +22,6 @@ import dev.nikomaru.advancerailway.file.data.ConfigData
 import dev.nikomaru.advancerailway.file.data.RailwayData
 import dev.nikomaru.advancerailway.file.value.RailwayId
 import dev.nikomaru.advancerailway.utils.Utils.json
-import dev.nikomaru.advancerailway.utils.coroutines.async
 import dev.nikomaru.advancerailway.utils.coroutines.minecraft
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -138,7 +137,7 @@ object RailwayUtils: KoinComponent {
 
     suspend fun getLine(
         startPoint: Point3D, directionPoint: Point3D, endPoint: Point3D
-    ): Either<RailTraceError, Line3D> = withContext(Dispatchers.async) {
+    ): Either<RailTraceError, Line3D> = withContext(Dispatchers.minecraft) {
         var previousPoint = startPoint
         var currentPoint = directionPoint
         var count = 0
@@ -185,7 +184,12 @@ object RailwayUtils: KoinComponent {
             if (!file.exists()) {
                 return@withContext Either.Left(DataSearchError.NOT_FOUND)
             }
-            return@withContext Either.Right(json.decodeFromString(file.readText()))
+            return@withContext try {
+                Either.Right(json.decodeFromString<RailwayData>(file.readText()))
+            } catch (e: Exception) {
+                plugin.logger.warning("Failed to decode railway data '${file.name}': ${e.message}")
+                Either.Left(DataSearchError.DESERIALIZATION_FAILED)
+            }
         }
 
 }

--- a/src/main/kotlin/dev/nikomaru/advancerailway/utils/StationUtils.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/utils/StationUtils.kt
@@ -35,9 +35,11 @@ object StationUtils: KoinComponent {
         val station =
             files.map { StationId(it.nameWithoutExtension) }.map { getStationData(it) }.filter { it.isRight() }
                 .map { it.getOrNull()!! }
-        val world = location.world //TODO 距離の計算を変更する ネザーの場合は8倍にする
+        val world = location.world //TODO 距離の計算を変更する ネザーの場合は8倍にする (nether distance scaling not yet implemented)
 
-        return@withContext Either.Right(station.minByOrNull { it.point.distanceTo2D(location.toPoint3D()) }!!.stationId)
+        val nearest = station.minByOrNull { it.point.distanceTo2D(location.toPoint3D()) }
+            ?: return@withContext Either.Left(DataSearchError.NOT_FOUND)
+        return@withContext Either.Right(nearest.stationId)
     }
 
     suspend fun getStationData(stationId: StationId): Either<DataSearchError, StationData> =
@@ -51,6 +53,11 @@ object StationUtils: KoinComponent {
             if (!file.exists()) {
                 return@withContext Either.Left(DataSearchError.NOT_FOUND)
             }
-            return@withContext Either.Right(json.decodeFromString(file.readText()))
+            return@withContext try {
+                Either.Right(json.decodeFromString<StationData>(file.readText()))
+            } catch (e: Exception) {
+                plugin.logger.warning("Failed to decode station data '${file.name}': ${e.message}")
+                Either.Left(DataSearchError.DESERIALIZATION_FAILED)
+            }
         }
 }

--- a/src/main/kotlin/dev/nikomaru/advancerailway/utils/command/GroupIdParser.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/utils/command/GroupIdParser.kt
@@ -9,40 +9,11 @@
 
 package dev.nikomaru.advancerailway.utils.command
 
-import dev.nikomaru.advancerailway.AdvanceRailway
 import dev.nikomaru.advancerailway.file.value.GroupId
-import org.bukkit.command.CommandSender
-import org.koin.core.component.KoinComponent
-import org.koin.core.component.inject
 import revxrsal.commands.bukkit.BukkitCommandHandler
-import revxrsal.commands.bukkit.sender
-import revxrsal.commands.command.CommandActor
-import revxrsal.commands.command.ExecutableCommand
-import revxrsal.commands.process.ValueResolver
 
-object GroupIdParser: ValueParser<GroupId>(), KoinComponent {
-    val plugin: AdvanceRailway by inject()
-    override fun suggestions(args: List<String>, sender: CommandSender, command: ExecutableCommand): Set<String> {
-        val file = plugin.dataFolder.resolve("data").resolve("groups")
-        if (!file.exists()) {
-            file.mkdirs()
-        }
-        return file.listFiles()?.map { it.nameWithoutExtension }?.toSet() ?: emptySet()
-    }
-
-    override fun resolve(context: ValueResolver.ValueResolverContext): GroupId {
-        val id = GroupId(context.pop())
-        return id
-    }
-
+object GroupIdParser: IdParser<GroupId>("groups", GroupId::class.java, ::GroupId) {
     fun BukkitCommandHandler.registerGroupIdParser() {
-        val handler = this
-        handler.autoCompleter.registerParameterSuggestions(
-            GroupId::class.java,
-        ) { args: List<String>, sender: CommandActor, command: ExecutableCommand ->
-            suggestions(args, sender.sender, command)
-        }
-        handler.registerValueResolver(GroupId::class.java, this@GroupIdParser)
+        registerIdParser()
     }
-
 }

--- a/src/main/kotlin/dev/nikomaru/advancerailway/utils/command/IdParser.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/utils/command/IdParser.kt
@@ -1,0 +1,64 @@
+/*
+ * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ *
+ * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication along with this software.
+ * If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+package dev.nikomaru.advancerailway.utils.command
+
+import dev.nikomaru.advancerailway.AdvanceRailway
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import org.bukkit.command.CommandSender
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import revxrsal.commands.bukkit.BukkitCommandHandler
+import revxrsal.commands.bukkit.sender
+import revxrsal.commands.command.CommandActor
+import revxrsal.commands.command.ExecutableCommand
+import revxrsal.commands.process.ValueResolver
+
+/**
+ * Shared implementation for id parsers (Group/Railway/Station) that are all backed by a
+ * per-type subfolder under the plugin's data directory (e.g. files under `data/groups/`), whose
+ * suggestions are simply the file names in that folder.
+ */
+abstract class IdParser<T: Any>(
+    private val subfolder: String,
+    private val idType: Class<T>,
+    private val idFactory: (String) -> T,
+): ValueParser<T>(), KoinComponent {
+    val plugin: AdvanceRailway by inject()
+
+    private val folder get() = plugin.dataFolder.resolve("data").resolve(subfolder)
+
+    /** Ensures the backing data folder exists. Call once at startup, never from [suggestions]. */
+    fun ensureDataFolder() {
+        if (!folder.exists()) {
+            folder.mkdirs()
+        }
+    }
+
+    override fun suggestions(args: List<String>, sender: CommandSender, command: ExecutableCommand): Set<String> =
+        runBlocking(Dispatchers.IO) {
+            folder.listFiles()?.map { it.nameWithoutExtension }?.toSet() ?: emptySet()
+        }
+
+    override fun resolve(context: ValueResolver.ValueResolverContext): T = idFactory(context.pop())
+
+    protected fun BukkitCommandHandler.registerIdParser() {
+        // Note: do NOT call ensureDataFolder() here. This runs from setCommand(), which
+        // executes before Koin is started (setupKoin()), and folder access resolves the
+        // lazily-injected `plugin` via Koin. Data folders are created explicitly, after
+        // Koin startup, by AdvanceRailway.onEnableAsync().
+        autoCompleter.registerParameterSuggestions(
+            idType,
+        ) { args: List<String>, sender: CommandActor, command: ExecutableCommand ->
+            suggestions(args, sender.sender, command)
+        }
+        registerValueResolver(idType, this@IdParser)
+    }
+}

--- a/src/main/kotlin/dev/nikomaru/advancerailway/utils/command/Point3DParser.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/utils/command/Point3DParser.kt
@@ -16,12 +16,13 @@ import revxrsal.commands.bukkit.BukkitCommandHandler
 import revxrsal.commands.bukkit.sender
 import revxrsal.commands.command.CommandActor
 import revxrsal.commands.command.ExecutableCommand
+import revxrsal.commands.exception.InvalidNumberException
 import revxrsal.commands.process.ValueResolver
 
 object Point3DParser: ValueParser<Point3D>() {
     override fun suggestions(args: List<String>, sender: CommandSender, command: ExecutableCommand): Set<String> {
-        if (sender !is Player) run {
-            println("You must be a player to use this command")
+        // Console/non-player senders simply get no location-based suggestion; nothing to log here.
+        if (sender !is Player) {
             return emptySet()
         }
         val loc = sender.location
@@ -30,10 +31,14 @@ object Point3DParser: ValueParser<Point3D>() {
     }
 
     override fun resolve(context: ValueResolver.ValueResolverContext): Point3D {
-        val list = context.pop().split(",").map { it.toDouble() }
-        val x = list[0]
-        val y = list[1]
-        val z = list[2]
+        val input = context.pop()
+        val components = input.split(",")
+        if (components.size != 3) {
+            throw InvalidNumberException(context.parameter(), input)
+        }
+        val (x, y, z) = components.map { component ->
+            component.toDoubleOrNull() ?: throw InvalidNumberException(context.parameter(), component)
+        }
         return Point3D(x, y, z)
     }
 

--- a/src/main/kotlin/dev/nikomaru/advancerailway/utils/command/RailwayIdParser.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/utils/command/RailwayIdParser.kt
@@ -9,40 +9,11 @@
 
 package dev.nikomaru.advancerailway.utils.command
 
-import dev.nikomaru.advancerailway.AdvanceRailway
 import dev.nikomaru.advancerailway.file.value.RailwayId
-import org.bukkit.command.CommandSender
-import org.koin.core.component.KoinComponent
-import org.koin.core.component.inject
 import revxrsal.commands.bukkit.BukkitCommandHandler
-import revxrsal.commands.bukkit.sender
-import revxrsal.commands.command.CommandActor
-import revxrsal.commands.command.ExecutableCommand
-import revxrsal.commands.process.ValueResolver
 
-object RailwayIdParser: ValueParser<RailwayId>(), KoinComponent {
-    val plugin: AdvanceRailway by inject()
-    override fun suggestions(args: List<String>, sender: CommandSender, command: ExecutableCommand): Set<String> {
-        val file = plugin.dataFolder.resolve("data").resolve("railways")
-        if (!file.exists()) {
-            file.mkdirs()
-        }
-        return file.listFiles()?.map { it.nameWithoutExtension }?.toSet() ?: emptySet()
-    }
-
-    override fun resolve(context: ValueResolver.ValueResolverContext): RailwayId {
-        val id = RailwayId(context.pop())
-        return id
-    }
-
+object RailwayIdParser: IdParser<RailwayId>("railways", RailwayId::class.java, ::RailwayId) {
     fun BukkitCommandHandler.registerRailwayIdParser() {
-        val handler = this
-        handler.autoCompleter.registerParameterSuggestions(
-            RailwayId::class.java,
-        ) { args: List<String>, sender: CommandActor, command: ExecutableCommand ->
-            suggestions(args, sender.sender, command)
-        }
-        handler.registerValueResolver(RailwayId::class.java, this@RailwayIdParser)
+        registerIdParser()
     }
-
 }

--- a/src/main/kotlin/dev/nikomaru/advancerailway/utils/command/StationIdParser.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/utils/command/StationIdParser.kt
@@ -9,40 +9,11 @@
 
 package dev.nikomaru.advancerailway.utils.command
 
-import dev.nikomaru.advancerailway.AdvanceRailway
 import dev.nikomaru.advancerailway.file.value.StationId
-import org.bukkit.command.CommandSender
-import org.koin.core.component.KoinComponent
-import org.koin.core.component.inject
 import revxrsal.commands.bukkit.BukkitCommandHandler
-import revxrsal.commands.bukkit.sender
-import revxrsal.commands.command.CommandActor
-import revxrsal.commands.command.ExecutableCommand
-import revxrsal.commands.process.ValueResolver
 
-object StationIdParser: ValueParser<StationId>(), KoinComponent {
-    val plugin: AdvanceRailway by inject()
-    override fun suggestions(args: List<String>, sender: CommandSender, command: ExecutableCommand): Set<String> {
-        val file = plugin.dataFolder.resolve("data").resolve("stations")
-        if (!file.exists()) {
-            file.mkdirs()
-        }
-        return file.listFiles()?.map { it.nameWithoutExtension }?.toSet() ?: emptySet()
-    }
-
-    override fun resolve(context: ValueResolver.ValueResolverContext): StationId {
-        val id = StationId(context.pop())
-        return id
-    }
-
+object StationIdParser: IdParser<StationId>("stations", StationId::class.java, ::StationId) {
     fun BukkitCommandHandler.registerStationIdParser() {
-        val handler = this
-        handler.autoCompleter.registerParameterSuggestions(
-            StationId::class.java,
-        ) { args: List<String>, sender: CommandActor, command: ExecutableCommand ->
-            suggestions(args, sender.sender, command)
-        }
-        handler.registerValueResolver(StationId::class.java, this@StationIdParser)
+        registerIdParser()
     }
-
 }

--- a/src/main/kotlin/dev/nikomaru/advancerailway/utils/coroutines/DispatcherContainer.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/utils/coroutines/DispatcherContainer.kt
@@ -14,30 +14,17 @@ import org.bukkit.plugin.java.JavaPlugin
 import kotlin.coroutines.CoroutineContext
 
 object DispatcherContainer {
-    private var asyncCoroutine: CoroutineContext? = null
-    private var syncCoroutine: CoroutineContext? = null
-
     /**
      * Gets the async coroutine context.
      */
-    val async: CoroutineContext
-        get() {
-            if (asyncCoroutine == null) {
-                asyncCoroutine = AsyncCoroutineDispatcher(JavaPlugin.getPlugin(AdvanceRailway::class.java))
-            }
-
-            return asyncCoroutine!!
-        }
+    val async: CoroutineContext by lazy {
+        AsyncCoroutineDispatcher(JavaPlugin.getPlugin(AdvanceRailway::class.java))
+    }
 
     /**
      * Gets the sync coroutine context.
      */
-    val sync: CoroutineContext
-        get() {
-            if (syncCoroutine == null) {
-                syncCoroutine = MinecraftCoroutineDispatcher(JavaPlugin.getPlugin(AdvanceRailway::class.java))
-            }
-
-            return syncCoroutine!!
-        }
+    val sync: CoroutineContext by lazy {
+        MinecraftCoroutineDispatcher(JavaPlugin.getPlugin(AdvanceRailway::class.java))
+    }
 }

--- a/src/test/kotlin/dev/nikomaru/advancerailway/file/utils/SerializerTest.kt
+++ b/src/test/kotlin/dev/nikomaru/advancerailway/file/utils/SerializerTest.kt
@@ -1,0 +1,139 @@
+/*
+ * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ *
+ * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication along with this software.
+ * If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+package dev.nikomaru.advancerailway.file.utils
+
+import dev.nikomaru.advancerailway.Line3D
+import dev.nikomaru.advancerailway.Point3D
+import dev.nikomaru.advancerailway.utils.Utils.json
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.awt.Color
+
+/**
+ * [Point3DSerializer] / [Line3DSerializer] / [ColorSerializer] の往復（encode -> decode -> encode）
+ * の安定性と、壊れた文字列を与えた際に静かに壊れたデータへ落ちずに例外を送出することを検証する。
+ * Bukkit には依存しない純粋なロジックのテスト。
+ */
+class SerializerTest {
+
+    // ---- Point3DSerializer ----
+
+    @Test
+    @DisplayName("Point3D round trips through encode -> decode -> encode")
+    fun point3DRoundTrips() {
+        val point = Point3D(12.5, -3.0, 100.25)
+        val encoded = json.encodeToString(Point3DSerializer, point)
+        val decoded = json.decodeFromString(Point3DSerializer, encoded)
+        assertEquals(point, decoded)
+        assertEquals(encoded, json.encodeToString(Point3DSerializer, decoded))
+    }
+
+    @Test
+    @DisplayName("Point3D deserialize throws instead of silently truncating on too few components")
+    fun point3DDeserializeThrowsOnTooFewComponents() {
+        assertThrows<Exception> {
+            json.decodeFromString(Point3DSerializer, "\"1.0,2.0\"")
+        }
+    }
+
+    @Test
+    @DisplayName("Point3D deserialize throws on non numeric components")
+    fun point3DDeserializeThrowsOnNonNumericComponents() {
+        assertThrows<Exception> {
+            json.decodeFromString(Point3DSerializer, "\"a,b,c\"")
+        }
+    }
+
+    @Test
+    @DisplayName("Point3D deserialize throws on empty string")
+    fun point3DDeserializeThrowsOnEmptyString() {
+        assertThrows<Exception> {
+            json.decodeFromString(Point3DSerializer, "\"\"")
+        }
+    }
+
+    // ---- Line3DSerializer ----
+
+    @Test
+    @DisplayName("Line3D round trips through encode -> decode -> encode")
+    fun line3DRoundTrips() {
+        val line = Line3D(Point3D(0.0, 64.0, 0.0), Point3D(10.0, 70.0, -5.0))
+        val encoded = json.encodeToString(Line3DSerializer, line)
+        val decoded = json.decodeFromString(Line3DSerializer, encoded)
+        assertEquals(line.points, decoded.points)
+        assertEquals(encoded, json.encodeToString(Line3DSerializer, decoded))
+    }
+
+    @Test
+    @DisplayName("Line3D round trips with additional intermediate points")
+    fun line3DRoundTripsWithIntermediatePoints() {
+        val line = Line3D(Point3D(0.0, 64.0, 0.0), Point3D(10.0, 64.0, 0.0))
+        // Non-collinear point so addPoint keeps it as a distinct vertex.
+        line.addPoint(Point3D(10.0, 70.0, 5.0))
+        val encoded = json.encodeToString(Line3DSerializer, line)
+        val decoded = json.decodeFromString(Line3DSerializer, encoded)
+        assertEquals(line.points, decoded.points)
+        assertEquals(encoded, json.encodeToString(Line3DSerializer, decoded))
+    }
+
+    @Test
+    @DisplayName("Line3D deserialize throws on malformed input without a separator")
+    fun line3DDeserializeThrowsOnMalformedInput() {
+        assertThrows<Exception> {
+            json.decodeFromString(Line3DSerializer, "\"garbage\"")
+        }
+    }
+
+    @Test
+    @DisplayName("Line3D deserialize throws on empty string")
+    fun line3DDeserializeThrowsOnEmptyString() {
+        assertThrows<Exception> {
+            json.decodeFromString(Line3DSerializer, "\"\"")
+        }
+    }
+
+    // ---- ColorSerializer ----
+
+    @Test
+    @DisplayName("Color round trips through encode -> decode -> encode")
+    fun colorRoundTrips() {
+        val color = Color(255, 128, 0)
+        val encoded = json.encodeToString(ColorSerializer, color)
+        val decoded = json.decodeFromString(ColorSerializer, encoded)
+        assertEquals(color, decoded)
+        assertEquals(encoded, json.encodeToString(ColorSerializer, decoded))
+    }
+
+    @Test
+    @DisplayName("Color deserialize throws on too few components")
+    fun colorDeserializeThrowsOnTooFewComponents() {
+        assertThrows<Exception> {
+            json.decodeFromString(ColorSerializer, "\"255,0\"")
+        }
+    }
+
+    @Test
+    @DisplayName("Color deserialize throws on non numeric components")
+    fun colorDeserializeThrowsOnNonNumericComponents() {
+        assertThrows<Exception> {
+            json.decodeFromString(ColorSerializer, "\"r,g,b\"")
+        }
+    }
+
+    @Test
+    @DisplayName("Color deserialize throws on out of range component")
+    fun colorDeserializeThrowsOnOutOfRangeComponent() {
+        assertThrows<Exception> {
+            json.decodeFromString(ColorSerializer, "\"300,0,0\"")
+        }
+    }
+}

--- a/src/test/kotlin/dev/nikomaru/advancerailway/file/value/IdValidationTest.kt
+++ b/src/test/kotlin/dev/nikomaru/advancerailway/file/value/IdValidationTest.kt
@@ -1,0 +1,86 @@
+/*
+ * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ *
+ * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication along with this software.
+ * If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+package dev.nikomaru.advancerailway.file.value
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+/**
+ * [IdValidation] と、それを利用する各 ID 値クラスのバリデーションを検証する（#116/#130）。
+ * パストラバーサル（`..`, `/`, `\`）やその URL エンコード表現を確実に弾くことを確認する。
+ */
+class IdValidationTest {
+
+    @Test
+    @DisplayName("isValid accepts ordinary alphanumeric ids")
+    fun isValidAcceptsOrdinaryIds() {
+        assertTrue(IdValidation.isValid("st01"))
+        assertTrue(IdValidation.isValid("Central_Line-1"))
+        assertTrue(IdValidation.isValid("a"))
+    }
+
+    @Test
+    @DisplayName("isValid rejects path traversal segments")
+    fun isValidRejectsPathTraversal() {
+        assertFalse(IdValidation.isValid(".."))
+        assertFalse(IdValidation.isValid("."))
+        assertFalse(IdValidation.isValid("../../x"))
+        assertFalse(IdValidation.isValid("..%2F..%2Fx"))
+    }
+
+    @Test
+    @DisplayName("isValid rejects path separators")
+    fun isValidRejectsPathSeparators() {
+        assertFalse(IdValidation.isValid("a/b"))
+        assertFalse(IdValidation.isValid("a\\b"))
+        assertFalse(IdValidation.isValid("/etc/passwd"))
+    }
+
+    @Test
+    @DisplayName("isValid rejects an empty string")
+    fun isValidRejectsEmptyString() {
+        assertFalse(IdValidation.isValid(""))
+    }
+
+    @Test
+    @DisplayName("isValid rejects embedded newlines and spaces")
+    fun isValidRejectsEmbeddedWhitespace() {
+        assertFalse(IdValidation.isValid("st01\n"))
+        assertFalse(IdValidation.isValid("st01 "))
+    }
+
+    @Test
+    @DisplayName("StationId constructor accepts a normal id")
+    fun stationIdAcceptsNormalId() {
+        assertEquals("st01", StationId("st01").value)
+    }
+
+    @Test
+    @DisplayName("StationId constructor rejects a URL-encoded traversal id")
+    fun stationIdRejectsTraversalId() {
+        assertThrows<IllegalArgumentException> { StationId("..%2F..%2Fx") }
+    }
+
+    @Test
+    @DisplayName("RailwayId constructor rejects a relative traversal id")
+    fun railwayIdRejectsTraversalId() {
+        assertThrows<IllegalArgumentException> { RailwayId("../../x") }
+    }
+
+    @Test
+    @DisplayName("GroupId constructor rejects a bare traversal id")
+    fun groupIdRejectsTraversalId() {
+        assertThrows<IllegalArgumentException> { GroupId("..") }
+    }
+}

--- a/src/test/kotlin/dev/nikomaru/advancerailway/mineauth/RailwayApiHandlerTest.kt
+++ b/src/test/kotlin/dev/nikomaru/advancerailway/mineauth/RailwayApiHandlerTest.kt
@@ -117,6 +117,15 @@ class RailwayApiHandlerTest {
     }
 
     @Test
+    @DisplayName("getStation rejects a path-traversal id with NOT_FOUND before touching disk")
+    fun getStationRejectsInvalidId() {
+        val error = assertThrows<HttpError> {
+            runBlocking { handler.getStation("../config") }
+        }
+        assertEquals(HttpStatus.NOT_FOUND, error.status)
+    }
+
+    @Test
     @DisplayName("listStations returns every station on disk")
     fun listStationsReturnsAll() = runBlocking {
         val response = handler.listStations()
@@ -151,6 +160,34 @@ class RailwayApiHandlerTest {
     }
 
     @Test
+    @DisplayName("getRailway throws NOT_FOUND for a missing id")
+    fun getRailwayNotFound() {
+        val error = assertThrows<HttpError> {
+            runBlocking { handler.getRailway("does-not-exist") }
+        }
+        assertEquals(HttpStatus.NOT_FOUND, error.status)
+    }
+
+    @Test
+    @DisplayName("getRailway rejects a URL-encoded path-traversal id with NOT_FOUND before touching disk")
+    fun getRailwayRejectsInvalidId() {
+        val error = assertThrows<HttpError> {
+            runBlocking { handler.getRailway("..%2F..%2Fx") }
+        }
+        assertEquals(HttpStatus.NOT_FOUND, error.status)
+    }
+
+    @Test
+    @DisplayName("listGroups returns every group on disk")
+    fun listGroupsReturnsAll() = runBlocking {
+        val response = handler.listGroups()
+
+        val groups = json.parseToJsonElement(response.text).jsonObject["groups"]!!.jsonArray
+        assertEquals(1, groups.size)
+        assertEquals("g1", groups.first().jsonObject["id"]!!.jsonPrimitive.content)
+    }
+
+    @Test
     @DisplayName("getGroup returns the group with a hex color")
     fun getGroupReturnsJson() = runBlocking {
         val response = handler.getGroup("g1")
@@ -166,6 +203,15 @@ class RailwayApiHandlerTest {
     fun getGroupNotFound() {
         val error = assertThrows<HttpError> {
             runBlocking { handler.getGroup("missing") }
+        }
+        assertEquals(HttpStatus.NOT_FOUND, error.status)
+    }
+
+    @Test
+    @DisplayName("getGroup rejects a relative path-traversal id with NOT_FOUND before touching disk")
+    fun getGroupRejectsInvalidId() {
+        val error = assertThrows<HttpError> {
+            runBlocking { handler.getGroup("../../x") }
         }
         assertEquals(HttpStatus.NOT_FOUND, error.status)
     }

--- a/src/test/kotlin/dev/nikomaru/advancerailway/utils/command/Point3DParserTest.kt
+++ b/src/test/kotlin/dev/nikomaru/advancerailway/utils/command/Point3DParserTest.kt
@@ -1,0 +1,75 @@
+/*
+ * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ *
+ * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication along with this software.
+ * If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+package dev.nikomaru.advancerailway.utils.command
+
+import dev.nikomaru.advancerailway.Point3D
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import revxrsal.commands.command.CommandParameter
+import revxrsal.commands.exception.InvalidNumberException
+import revxrsal.commands.process.ValueResolver
+
+/**
+ * [Point3DParser.resolve] が壊れた入力（引数の数が違う・数値でない）に対して
+ * クラッシュせず [InvalidNumberException] を送出することを確認する（#134 の回帰防止）。
+ */
+class Point3DParserTest {
+
+    private fun contextFor(input: String): ValueResolver.ValueResolverContext {
+        val context = mockk<ValueResolver.ValueResolverContext>()
+        val parameter = mockk<CommandParameter>(relaxed = true)
+        every { context.pop() } returns input
+        every { context.parameter() } returns parameter
+        return context
+    }
+
+    @Test
+    @DisplayName("resolve parses a well formed comma separated point")
+    fun resolveParsesWellFormedPoint() {
+        val point = Point3DParser.resolve(contextFor("1.5,2,-3.25"))
+        assertEquals(Point3D(1.5, 2.0, -3.25), point)
+    }
+
+    @Test
+    @DisplayName("resolve throws InvalidNumberException when too few components are given")
+    fun resolveThrowsOnTooFewComponents() {
+        assertThrows<InvalidNumberException> {
+            Point3DParser.resolve(contextFor("1,2"))
+        }
+    }
+
+    @Test
+    @DisplayName("resolve throws InvalidNumberException when too many components are given")
+    fun resolveThrowsOnTooManyComponents() {
+        assertThrows<InvalidNumberException> {
+            Point3DParser.resolve(contextFor("1,2,3,4"))
+        }
+    }
+
+    @Test
+    @DisplayName("resolve throws InvalidNumberException on non numeric components")
+    fun resolveThrowsOnNonNumericComponents() {
+        assertThrows<InvalidNumberException> {
+            Point3DParser.resolve(contextFor("a,b,c"))
+        }
+    }
+
+    @Test
+    @DisplayName("resolve throws InvalidNumberException on blank input")
+    fun resolveThrowsOnBlankInput() {
+        assertThrows<InvalidNumberException> {
+            Point3DParser.resolve(contextFor(""))
+        }
+    }
+}


### PR DESCRIPTION
自動監査 (#116–#143) で挙がった改善点のうち、実装可能な項目をサブシステム単位で対応しました。難易度に応じて opus / sonnet / haiku のエージェントに分担し、各コミットを 1 サブシステムに対応させています。

## 検証
- `./gradlew build`（テスト含む）**成功**、`48 tests / 0 failures`
- 新規テスト: `SerializerTest`, `IdValidationTest`（パストラバーサル拒否含む）, `Point3DParserTest`, `RailwayApiHandlerTest` 拡充
- ベースラインもグリーンであることを事前確認済み

## コミット構成と対応 Issue

| コミット | 対応 |
| --- | --- |
| 🔒 ID 検証の一元化・値クラス equals/hashCode | #116(値層), #130, #132 |
| 💾 永続化の堅牢化（アトミック書込・破損隔離・安定色） | #119, #120, #122, #133 |
| 🧵 スレッド親和性・NPE 強制アンラップ修正 | #121, #123, #137(一部) |
| 🧩 ID パーサ重複排除・Point3DParser クラッシュ耐性 | #134, #136 |
| 🎛️ コマンド修正（ガード・権限分離・参照整合性・重複排除） | #118, #127, #128, #129, #130, #131, #135, #141, #142 |
| 🌐 MineAuth HTTP API のセキュア化・ページング | #116(handler), #117, #143 |
| ✅ テスト追加 | #126(一部) |
| 👷 CI の実効ゲート化・リリース JDK を 25 に | #124, #125 |
| 📝 README/英語 docs/API リファレンス/日本語構文修正 | #138, #139, #140 |

## 補足・レビュー観点
- **#117**: 座標を含むため fail-safe 方針。全エンドポイントを `@Permission("advancerailway.mineauth.read")` で保護し、`mineAuthEnabled` 設定フラグで連携自体を無効化可能（デフォルト有効・権限必須）。座標のデフォルト公開はしていません。
- **#116 の設計**: `StationId/RailwayId/GroupId` の `init` で `require(IdValidation.isValid)`。既存の正当な ID（`[A-Za-z0-9_-]+`）は影響なし。ローダは各ファイルを try/catch で隔離するため、万一非準拠のファイルがあってもロード全体は落ちずスキップ・ログされます。
- **#137**: 侵襲を避けるため今回は unsafe な lazy init 修正のみ。`mccoroutine` への全面移行は follow-up として保留。
- **#126**: 全面カバレッジではなく高価値な純粋ロジック中心に限定。残りは follow-up 推奨。
- **#125**: 本リポジトリは detekt を `ignoreFailures = true`（段階導入）に設定しているため、CI ゲート強化はテスト実行の必須化が中心です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
