### PR TITLE
⬆️ Migrate MineAuth integration to the 0.2.33 API

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,9 +61,8 @@ dependencies {
     compileOnly(libs.protocolLib)
 
     // MineAuth HTTP API 連携。MineAuth 本体（softdepend）から実行時に提供されるため compileOnly。
+    // ハンドラーは @Serializable な DTO をそのまま返し、シリアライズは MineAuth 側が担う。
     compileOnly(libs.mineauth.api)
-    // ハンドラーの戻り値を生 JSON（TextContent）として返すために利用。Ktor も MineAuth 側が提供する。
-    compileOnly(libs.ktor.http)
 
     implementation(libs.arrow.core)
     implementation(libs.arrow.fx.coroutines)
@@ -79,10 +78,9 @@ dependencies {
     // MockBukkit 4.110.0 が実装するレジストリ ABI に合わせ、テストでは 1.21.11 の paper-api を使う
     // （main の 26.x は compileOnly なのでテスト実行クラスパスには載らず、競合しない）。
     testImplementation(libs.paper.api.test)
-    // ハンドラーが返す TextContent / throw する HttpError をテストから参照するため
+    // ハンドラーが返す DTO / throw する HttpError をテストから参照するため
     // （main では compileOnly のためテストクラスパスには別途載せる）。
     testImplementation(libs.mineauth.api)
-    testImplementation(libs.ktor.http)
 }
 
 java {
@@ -112,7 +110,7 @@ tasks {
     shadowJar {
         // 他プラグインとの衝突を避けるため、AdvanceRailway 固有のライブラリを relocate する。
         // kotlin stdlib / kotlinx.serialization / coroutines は relocate しない
-        // （MineAuth 連携は TextContent で生 JSON を返すためシリアライザの共有は不要）。
+        // （MineAuth 連携は @Serializable DTO を返し、MineAuth 側がそのシリアライザを解決するため）。
         relocate("org.koin", "dev.nikomaru.advancerailway.libs.koin")
         relocate("arrow", "dev.nikomaru.advancerailway.libs.arrow")
         relocate("revxrsal.commands", "dev.nikomaru.advancerailway.libs.lamp")

--- a/docs/docs/en/mineauth-api.md
+++ b/docs/docs/en/mineauth-api.md
@@ -26,12 +26,16 @@ stations is `/api/v1/plugins/advancerailway/stations`.
 
 A by-id request for an id that does not exist returns an HTTP `404 Not Found` error.
 
-## Authentication / permissions
+## Authentication
 
-All six endpoints are gated with the `@Permission("advancerailway.mineauth.read")` annotation, so a
-caller must hold the `advancerailway.mineauth.read` permission node (enforced by MineAuth) to read
-railway data. The endpoints expose exact in-world coordinates, so grant this node only to trusted
-callers.
+All six endpoints are declared `@Authenticated(callers = [CallerType.SERVICE])`, so they can only be
+called with a **service-account token** — a trusted credential that a server administrator issues via
+MineAuth. Player user tokens (issued through MineAuth's OAuth2 flow) are rejected. The endpoints expose
+exact in-world coordinates, so issue service tokens only to trusted backend integrations.
+
+Because service tokens are treated as trusted credentials, MineAuth does **not** evaluate any Bukkit
+permission node for them; access is controlled purely by whether the caller holds a valid service token.
+(This replaces the previous `advancerailway.mineauth.read` permission-node gate.)
 
 The integration can also be disabled entirely via config (`mineAuthEnabled: false` in the plugin
 config); when disabled, `MineAuthIntegration` does not register the handler even if MineAuth is present.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,8 +10,7 @@ csvSerializationVersion = "2.1.0"
 protocolLibVersion = "5.3.0"
 junitVersion = "6.1.1"
 arrow-ktVersion = "2.2.3"
-mineauthVersion = "0.2.30"
-ktorVersion = "3.5.1"
+mineauthVersion = "0.2.33"
 mockbukkitVersion = "4.110.0"
 mockkVersion = "1.14.11"
 # MockBukkit 4.110.0 がターゲットとする paper-api（テスト実行時のみ使用）。
@@ -34,7 +33,6 @@ arrow-fx-coroutines = { group = "io.arrow-kt", name = "arrow-fx-coroutines", ver
 junit-jupiter = { group = "org.junit.jupiter", name = "junit-jupiter", version.ref = "junitVersion" }
 junit-platform-launcher = { group = "org.junit.platform", name = "junit-platform-launcher" }
 mineauth-api = { group = "party.morino", name = "mineauth-api", version.ref = "mineauthVersion" }
-ktor-http = { group = "io.ktor", name = "ktor-http", version.ref = "ktorVersion" }
 mockbukkit = { group = "org.mockbukkit.mockbukkit", name = "mockbukkit-v1.21", version.ref = "mockbukkitVersion" }
 mockk = { group = "io.mockk", name = "mockk", version.ref = "mockkVersion" }
 paper-api-test = { group = "io.papermc.paper", name = "paper-api", version.ref = "paperTestVersion" }

--- a/src/main/kotlin/dev/nikomaru/advancerailway/file/data/ConfigData.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/file/data/ConfigData.kt
@@ -21,7 +21,7 @@ data class ConfigData(
     /**
      * MineAuth の HTTP API 連携を有効にするか。
      * false の場合、MineAuth が導入されていてもエンドポイントを登録しない。
-     * 有効時もエンドポイントは権限（advancerailway.mineauth.read）で保護される。
+     * 有効時もエンドポイントはサービストークンでの認証で保護される。
      */
     val mineAuthEnabled: Boolean = true,
 )

--- a/src/main/kotlin/dev/nikomaru/advancerailway/mineauth/MineAuthIntegration.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/mineauth/MineAuthIntegration.kt
@@ -13,7 +13,8 @@ import dev.nikomaru.advancerailway.AdvanceRailway
 import dev.nikomaru.advancerailway.file.data.ConfigData
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.get
-import party.morino.mineauth.api.MineAuthAPI
+import party.morino.mineauth.api.EndpointRegistrationException
+import party.morino.mineauth.api.MineAuthApi
 
 /**
  * MineAuth との連携をセットアップするエントリーポイント。
@@ -26,7 +27,11 @@ object MineAuthIntegration : KoinComponent {
      * 登録後、エンドポイントは `/api/v1/plugins/advancerailway/` 配下で利用可能になる。
      *
      * ただし [ConfigData.mineAuthEnabled] が false の場合は登録をスキップする（フェイルセーフ）。
-     * 登録した場合でも各エンドポイントは権限で保護される（[RailwayApiHandler] 参照）。
+     * 登録した場合でも各エンドポイントはサービストークンでの認証で保護される（[RailwayApiHandler] 参照）。
+     *
+     * MineAuth の [MineAuthApi] は Bukkit の ServicesManager 経由で取得する。
+     * 登録は all-or-nothing で、検証に失敗すると [EndpointRegistrationException] が送出されるため、
+     * その場合でも onEnable を巻き込まないようフェイルセーフでログのみ出力する。
      *
      * @param plugin AdvanceRailway 本体
      */
@@ -38,15 +43,19 @@ object MineAuthIntegration : KoinComponent {
             return
         }
 
-        // MineAuth 本体を安全にキャストして取得する（未導入・非対応バージョンでは null）。
-        val api = plugin.server.pluginManager.getPlugin("MineAuth") as? MineAuthAPI
+        // MineAuth 本体を ServicesManager 経由で取得する（未導入・非対応バージョンでは null）。
+        val api = MineAuthApi.get(plugin.server)
         if (api == null) {
             plugin.logger.info("MineAuth not found; skipping HTTP endpoint registration.")
             return
         }
 
-        api.createHandler(plugin)
-            .register(RailwayApiHandler())
-        plugin.logger.info("Registered MineAuth HTTP endpoints under /api/v1/plugins/advancerailway/")
+        try {
+            val registration = api.register(plugin, RailwayApiHandler())
+            plugin.logger.info("Registered MineAuth HTTP endpoints under ${registration.basePath}")
+        } catch (e: EndpointRegistrationException) {
+            // 検証エラーで登録に失敗しても AdvanceRailway 本体の起動は継続する。
+            plugin.logger.warning("Failed to register MineAuth HTTP endpoints: ${e.message}")
+        }
     }
 }

--- a/src/main/kotlin/dev/nikomaru/advancerailway/mineauth/RailwayApiHandler.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/mineauth/RailwayApiHandler.kt
@@ -27,18 +27,15 @@ import dev.nikomaru.advancerailway.mineauth.dto.StationsResponse
 import dev.nikomaru.advancerailway.utils.GroupUtils
 import dev.nikomaru.advancerailway.utils.RailwayUtils
 import dev.nikomaru.advancerailway.utils.StationUtils
-import dev.nikomaru.advancerailway.utils.Utils.json
-import io.ktor.http.ContentType
-import io.ktor.http.content.TextContent
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import kotlinx.serialization.SerializationStrategy
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
-import party.morino.mineauth.api.annotations.GetMapping
-import party.morino.mineauth.api.annotations.PathParam
-import party.morino.mineauth.api.annotations.Permission
-import party.morino.mineauth.api.annotations.QueryParams
+import party.morino.mineauth.api.CallerType
+import party.morino.mineauth.api.annotations.Authenticated
+import party.morino.mineauth.api.annotations.Get
+import party.morino.mineauth.api.annotations.Path
+import party.morino.mineauth.api.annotations.Query
 import party.morino.mineauth.api.http.HttpError
 import party.morino.mineauth.api.http.HttpStatus
 import java.io.File
@@ -47,17 +44,18 @@ import java.io.File
  * MineAuth の HTTP API へ AdvanceRailway の駅・路線・グループデータを公開するハンドラー。
  * `/api/v1/plugins/advancerailway/` 配下に読み取り専用エンドポイントを提供する。
  *
- * 戻り値は [dev.nikomaru.advancerailway.utils.Utils.json] で JSON へ変換した [TextContent] とする。
- * MineAuth 側はこれを生の JSON としてそのまま書き出すため、プラグイン間で kotlinx.serialization の
- * シリアライザ実体を共有する必要がなくなる。
+ * 各エンドポイントは [Authenticated] で保護し、`callers = [CallerType.SERVICE]` を指定して
+ * 管理者が発行したサービストークンからのみ呼び出せるようにする（プレイヤーのユーザートークンは拒否）。
+ * サービストークンは信頼された資格情報として扱われ、パーミッションノードの評価対象外となるため、
+ * ここでは permission を指定しない。
+ *
+ * ハンドラーは [kotlinx.serialization.Serializable] な DTO をそのまま返し、
+ * JSON へのシリアライズは MineAuth 側が担う。
  */
 class RailwayApiHandler : KoinComponent {
     private val plugin: AdvanceRailway by inject()
 
     companion object {
-        /** すべての読み取りエンドポイントに要求する権限ノード。 */
-        const val READ_PERMISSION = "advancerailway.mineauth.read"
-
         /** limit 未指定時に返す件数の既定値。 */
         const val DEFAULT_LIMIT = 100
 
@@ -68,100 +66,111 @@ class RailwayApiHandler : KoinComponent {
     /**
      * limit/offset のクエリパラメータを健全な範囲に正規化する。
      *
-     * - offset: 0 以上（負値・不正値は 0 に丸める）。
-     * - limit: 1..[MAX_LIMIT] の範囲。未指定・不正値は [DEFAULT_LIMIT]。
+     * - offset: 0 以上（負値・未指定は 0 に丸める）。
+     * - limit: 1..[MAX_LIMIT] の範囲。未指定は [DEFAULT_LIMIT]。
+     *
+     * @return `(skip, take)` のペア。
      */
-    private fun paging(params: Map<String, String>): Pair<Int, Int> {
-        val offset = params["offset"]?.toIntOrNull()?.coerceAtLeast(0) ?: 0
-        val limit = (params["limit"]?.toIntOrNull() ?: DEFAULT_LIMIT).coerceIn(1, MAX_LIMIT)
-        return offset to limit
+    private fun paging(limit: Int?, offset: Int?): Pair<Int, Int> {
+        val skip = (offset ?: 0).coerceAtLeast(0)
+        val take = (limit ?: DEFAULT_LIMIT).coerceIn(1, MAX_LIMIT)
+        return skip to take
     }
 
     /**
      * すべての駅を取得する（limit/offset でページングする）。
      * GET /stations?limit={n}&offset={n}
      */
-    @Permission(READ_PERMISSION)
-    @GetMapping("/stations")
-    suspend fun listStations(@QueryParams params: Map<String, String> = emptyMap()): TextContent {
-        val (offset, limit) = paging(params)
+    @Get("/stations")
+    @Authenticated(callers = [CallerType.SERVICE])
+    suspend fun listStations(
+        @Query("limit") limit: Int? = null,
+        @Query("offset") offset: Int? = null,
+    ): StationsResponse {
+        val (skip, take) = paging(limit, offset)
         val stations = listIds("stations")
-            .drop(offset)
-            .take(limit)
+            .drop(skip)
+            .take(take)
             .mapNotNull { StationUtils.getStationData(StationId(it)).getOrNull() }
             .map { it.toDto() }
-        return json(StationsResponse(stations), StationsResponse.serializer())
+        return StationsResponse(stations)
     }
 
     /**
      * 指定した駅を取得する。
      * GET /stations/{id}
      */
-    @Permission(READ_PERMISSION)
-    @GetMapping("/stations/{id}")
-    suspend fun getStation(@PathParam("id") id: String): TextContent {
+    @Get("/stations/{id}")
+    @Authenticated(callers = [CallerType.SERVICE])
+    suspend fun getStation(@Path("id") id: String): StationDto {
         if (!IdValidation.isValid(id)) throw HttpError(HttpStatus.NOT_FOUND, "Station not found: $id")
         val station = StationUtils.getStationData(StationId(id)).getOrNull()
             ?: throw HttpError(HttpStatus.NOT_FOUND, "Station not found: $id")
-        return json(station.toDto(), StationDto.serializer())
+        return station.toDto()
     }
 
     /**
      * すべての路線を取得する（limit/offset でページングする）。
      * GET /railways?limit={n}&offset={n}
      */
-    @Permission(READ_PERMISSION)
-    @GetMapping("/railways")
-    suspend fun listRailways(@QueryParams params: Map<String, String> = emptyMap()): TextContent {
-        val (offset, limit) = paging(params)
+    @Get("/railways")
+    @Authenticated(callers = [CallerType.SERVICE])
+    suspend fun listRailways(
+        @Query("limit") limit: Int? = null,
+        @Query("offset") offset: Int? = null,
+    ): RailwaysResponse {
+        val (skip, take) = paging(limit, offset)
         val railways = listIds("railways")
-            .drop(offset)
-            .take(limit)
+            .drop(skip)
+            .take(take)
             .mapNotNull { RailwayUtils.getRailwayData(RailwayId(it)).getOrNull() }
             .map { it.toDto() }
-        return json(RailwaysResponse(railways), RailwaysResponse.serializer())
+        return RailwaysResponse(railways)
     }
 
     /**
      * 指定した路線を取得する。
      * GET /railways/{id}
      */
-    @Permission(READ_PERMISSION)
-    @GetMapping("/railways/{id}")
-    suspend fun getRailway(@PathParam("id") id: String): TextContent {
+    @Get("/railways/{id}")
+    @Authenticated(callers = [CallerType.SERVICE])
+    suspend fun getRailway(@Path("id") id: String): RailwayDto {
         if (!IdValidation.isValid(id)) throw HttpError(HttpStatus.NOT_FOUND, "Railway not found: $id")
         val railway = RailwayUtils.getRailwayData(RailwayId(id)).getOrNull()
             ?: throw HttpError(HttpStatus.NOT_FOUND, "Railway not found: $id")
-        return json(railway.toDto(), RailwayDto.serializer())
+        return railway.toDto()
     }
 
     /**
      * すべてのグループを取得する（limit/offset でページングする）。
      * GET /groups?limit={n}&offset={n}
      */
-    @Permission(READ_PERMISSION)
-    @GetMapping("/groups")
-    suspend fun listGroups(@QueryParams params: Map<String, String> = emptyMap()): TextContent {
-        val (offset, limit) = paging(params)
+    @Get("/groups")
+    @Authenticated(callers = [CallerType.SERVICE])
+    suspend fun listGroups(
+        @Query("limit") limit: Int? = null,
+        @Query("offset") offset: Int? = null,
+    ): GroupsResponse {
+        val (skip, take) = paging(limit, offset)
         val groups = listIds("groups")
-            .drop(offset)
-            .take(limit)
+            .drop(skip)
+            .take(take)
             .mapNotNull { GroupUtils.getGroupData(GroupId(it)).getOrNull() }
             .map { it.toDto() }
-        return json(GroupsResponse(groups), GroupsResponse.serializer())
+        return GroupsResponse(groups)
     }
 
     /**
      * 指定したグループを取得する。
      * GET /groups/{id}
      */
-    @Permission(READ_PERMISSION)
-    @GetMapping("/groups/{id}")
-    suspend fun getGroup(@PathParam("id") id: String): TextContent {
+    @Get("/groups/{id}")
+    @Authenticated(callers = [CallerType.SERVICE])
+    suspend fun getGroup(@Path("id") id: String): GroupDto {
         if (!IdValidation.isValid(id)) throw HttpError(HttpStatus.NOT_FOUND, "Group not found: $id")
         val group = GroupUtils.getGroupData(GroupId(id)).getOrNull()
             ?: throw HttpError(HttpStatus.NOT_FOUND, "Group not found: $id")
-        return json(group.toDto(), GroupDto.serializer())
+        return group.toDto()
     }
 
     /**
@@ -176,13 +185,6 @@ class RailwayApiHandler : KoinComponent {
             ?.sorted()
             ?: emptyList()
     }
-
-    /**
-     * DTO を [dev.nikomaru.advancerailway.utils.Utils.json] で JSON 化し、
-     * application/json の [TextContent] として返すヘルパー。
-     */
-    private fun <T> json(value: T, serializer: SerializationStrategy<T>): TextContent =
-        TextContent(json.encodeToString(serializer, value), ContentType.Application.Json)
 
     private fun StationData.toDto(): StationDto = StationDto(
         id = stationId.value,

--- a/src/main/kotlin/dev/nikomaru/advancerailway/mineauth/dto/RailwayDtos.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/mineauth/dto/RailwayDtos.kt
@@ -16,9 +16,8 @@ import kotlinx.serialization.Serializable
  *
  * これらは Bukkit 型（World / Color など）や独自の value class を含まず、
  * プリミティブと文字列のみで構成する。
- * AdvanceRailway 自身の [dev.nikomaru.advancerailway.utils.Utils.json] で JSON 文字列へ変換し、
- * Ktor の TextContent として生 JSON を返すことで、プラグイン間クラスローダをまたぐ
- * シリアライザの不整合を回避する。
+ * [RailwayApiHandler] はこれらの `@Serializable` DTO をそのまま返し、
+ * JSON へのシリアライズは MineAuth 側が各 DTO のシリアライザを解決して行う。
  */
 
 /** 3 次元座標。 */

--- a/src/test/kotlin/dev/nikomaru/advancerailway/mineauth/RailwayApiHandlerTest.kt
+++ b/src/test/kotlin/dev/nikomaru/advancerailway/mineauth/RailwayApiHandlerTest.kt
@@ -20,13 +20,9 @@ import dev.nikomaru.advancerailway.file.value.GroupId
 import dev.nikomaru.advancerailway.file.value.RailwayId
 import dev.nikomaru.advancerailway.file.value.StationId
 import dev.nikomaru.advancerailway.utils.Utils.json
-import io.ktor.http.ContentType
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
-import kotlinx.serialization.json.jsonArray
-import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
 import org.bukkit.World
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -94,17 +90,15 @@ class RailwayApiHandlerTest {
     }
 
     @Test
-    @DisplayName("getStation returns the station as application/json")
-    fun getStationReturnsJson() = runBlocking {
-        val response = handler.getStation("st01")
+    @DisplayName("getStation returns the station DTO")
+    fun getStationReturnsDto() = runBlocking {
+        val station = handler.getStation("st01")
 
-        assertEquals(ContentType.Application.Json, response.contentType)
-        val obj = json.parseToJsonElement(response.text).jsonObject
-        assertEquals("st01", obj["id"]!!.jsonPrimitive.content)
-        assertEquals("Central", obj["name"]!!.jsonPrimitive.content)
-        assertEquals("world", obj["world"]!!.jsonPrimitive.content)
-        assertEquals("#FF7F00", obj["color"]!!.jsonPrimitive.content)
-        assertEquals("64.0", obj["point"]!!.jsonObject["y"]!!.jsonPrimitive.content)
+        assertEquals("st01", station.id)
+        assertEquals("Central", station.name)
+        assertEquals("world", station.world)
+        assertEquals("#FF7F00", station.color)
+        assertEquals(64.0, station.point.y)
     }
 
     @Test
@@ -130,23 +124,21 @@ class RailwayApiHandlerTest {
     fun listStationsReturnsAll() = runBlocking {
         val response = handler.listStations()
 
-        val stations = json.parseToJsonElement(response.text).jsonObject["stations"]!!.jsonArray
-        assertEquals(2, stations.size)
-        val ids = stations.map { it.jsonObject["id"]!!.jsonPrimitive.content }.toSet()
+        assertEquals(2, response.stations.size)
+        val ids = response.stations.map { it.id }.toSet()
         assertEquals(setOf("st01", "st02"), ids)
     }
 
     @Test
     @DisplayName("getRailway maps line/stations/points to the DTO")
-    fun getRailwayReturnsJson() = runBlocking {
-        val response = handler.getRailway("rw01")
+    fun getRailwayReturnsDto() = runBlocking {
+        val railway = handler.getRailway("rw01")
 
-        val obj = json.parseToJsonElement(response.text).jsonObject
-        assertEquals("rw01", obj["id"]!!.jsonPrimitive.content)
-        assertEquals("UP_LINE", obj["lineType"]!!.jsonPrimitive.content)
-        assertEquals("st01", obj["fromStation"]!!.jsonPrimitive.content)
-        assertEquals("st02", obj["toStation"]!!.jsonPrimitive.content)
-        assertEquals("120", obj["timeRequired"]!!.jsonPrimitive.content)
+        assertEquals("rw01", railway.id)
+        assertEquals("UP_LINE", railway.lineType)
+        assertEquals("st01", railway.fromStation)
+        assertEquals("st02", railway.toStation)
+        assertEquals(120L, railway.timeRequired)
     }
 
     @Test
@@ -154,9 +146,8 @@ class RailwayApiHandlerTest {
     fun listRailwaysReturnsAll() = runBlocking {
         val response = handler.listRailways()
 
-        val railways = json.parseToJsonElement(response.text).jsonObject["railways"]!!.jsonArray
-        assertEquals(1, railways.size)
-        assertEquals("rw01", railways.first().jsonObject["id"]!!.jsonPrimitive.content)
+        assertEquals(1, response.railways.size)
+        assertEquals("rw01", response.railways.first().id)
     }
 
     @Test
@@ -182,20 +173,18 @@ class RailwayApiHandlerTest {
     fun listGroupsReturnsAll() = runBlocking {
         val response = handler.listGroups()
 
-        val groups = json.parseToJsonElement(response.text).jsonObject["groups"]!!.jsonArray
-        assertEquals(1, groups.size)
-        assertEquals("g1", groups.first().jsonObject["id"]!!.jsonPrimitive.content)
+        assertEquals(1, response.groups.size)
+        assertEquals("g1", response.groups.first().id)
     }
 
     @Test
     @DisplayName("getGroup returns the group with a hex color")
-    fun getGroupReturnsJson() = runBlocking {
-        val response = handler.getGroup("g1")
+    fun getGroupReturnsDto() = runBlocking {
+        val group = handler.getGroup("g1")
 
-        val obj = json.parseToJsonElement(response.text).jsonObject
-        assertEquals("g1", obj["id"]!!.jsonPrimitive.content)
-        assertEquals("Yamanote", obj["name"]!!.jsonPrimitive.content)
-        assertEquals("#00FF00", obj["color"]!!.jsonPrimitive.content)
+        assertEquals("g1", group.id)
+        assertEquals("Yamanote", group.name)
+        assertEquals("#00FF00", group.color)
     }
 
     @Test


### PR DESCRIPTION
## What

MineAuth redesigned its HTTP API between `0.2.30` and `0.2.33` (annotations, registration entrypoint, response handling, and access model all changed). This PR migrates the AdvanceRailway integration to the new contract.

## Changes

**Dependency** — bump `mineauth-api` `0.2.30` → `0.2.33`; drop the now-unused `ktor-http` dependency.

**Handler (`RailwayApiHandler`)** — old → new API mapping:

| old (0.2.30) | new (0.2.33) |
| --- | --- |
| `@GetMapping("/x")` | `@Get("/x")` |
| `@Permission("...read")` | `@Authenticated(callers = [CallerType.SERVICE])` |
| `@PathParam("id")` | `@Path("id")` |
| `@QueryParams params: Map` | typed `@Query("limit") limit: Int?` / `@Query("offset")` |
| return `TextContent` (self-encoded raw JSON) | return the `@Serializable` DTO directly (MineAuth serializes it) |

**Registration (`MineAuthIntegration`)** — acquire the API via `MineAuthApi.get(server)` (ServicesManager) instead of casting `getPlugin("MineAuth")`; register with `api.register(plugin, RailwayApiHandler())`; catch `EndpointRegistrationException` so a validation failure never kills `onEnable`; log `registration.basePath` on success.

**Access model** — endpoints are now `@Authenticated(callers = [CallerType.SERVICE])`: only admin-issued **service tokens** can read (player user tokens are rejected). Service tokens bypass Bukkit permission nodes, so the previous `advancerailway.mineauth.read` node is removed rather than left as dead, misleading config. Documented in `docs/docs/en/mineauth-api.md`.

**Housekeeping** — updated stale DTO/config/build comments and rewrote the handler tests to assert on returned DTOs.

## Verification

- `./gradlew build` — **BUILD SUCCESSFUL** (compile + detekt + full test suite)
- mineauth tests re-run with `--rerun-tasks`, all pass

⚠️ Tests call the handler directly and assert on returned DTOs, so they verify the **DTO mapping** but not MineAuth's over-the-wire serialization path (DTO → JSON), which is MineAuth's responsibility and only exercises with MineAuth loaded on a live server.