### PR TITLE
👷 Spotless によるライセンスヘッダーの一元管理＋年の自動更新

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -100,26 +100,23 @@ detekt {
 }
 
 spotless {
-    // 変更のあったファイルのみ対象にし、ライセンスヘッダーの年を「元の年-現在の年」の範囲へ自動更新する
-    // （例: 2024 のファイルを編集すると 2024-2026 になる）。未変更ファイルは触らない。
-    ratchetFrom("origin/master")
-
     // detekt と同様、当面は非ゲート（`check`/`build` を失敗させない）。開発者が任意に
     // `./gradlew spotlessApply`（一括付与・更新）/ `spotlessCheck`（検証）を実行する運用とする。
-    // 将来 CI ゲート化する場合は isEnforceCheck=true にし、CI の checkout に fetch-depth: 0 を付ける
-    // （ratchetFrom が origin/master の履歴を必要とするため）。
     isEnforceCheck = false
 
     // ライセンスヘッダーは config/spotless/license-header.kt に一元管理し、$YEAR トークンで年を表す。
+    // updateYearWithLatest により、既存の年（2024）を「2024-現在年」の範囲へ更新する
+    // （例: 2024 → 2024-2026）。新規ファイルは現在年のみ。全ファイルを対象にするため ratchet は使わない。
     val licenseHeader = rootProject.file("config/spotless/license-header.kt")
     kotlin {
         target("src/**/*.kt")
-        licenseHeaderFile(licenseHeader)
+        licenseHeaderFile(licenseHeader).updateYearWithLatest(true)
     }
     kotlinGradle {
         target("*.gradle.kts")
         // .gradle.kts の最初の非ヘッダー行（build: import / settings: pluginManagement 等）を区切りとする。
         licenseHeaderFile(licenseHeader, "(import|plugins|pluginManagement|dependencyResolutionManagement|rootProject|@file)")
+            .updateYearWithLatest(true)
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *
@@ -19,6 +19,7 @@ plugins {
     alias(libs.plugins.run.paper)
     alias(libs.plugins.resource.factory)
     alias(libs.plugins.detekt)
+    alias(libs.plugins.spotless)
 }
 
 group = "dev.nikomaru"
@@ -96,6 +97,30 @@ detekt {
     // 段階的に導入するため、指摘があってもビルドは失敗させない。
     ignoreFailures = true
     source.setFrom("src/main/kotlin", "src/test/kotlin")
+}
+
+spotless {
+    // 変更のあったファイルのみ対象にし、ライセンスヘッダーの年を「元の年-現在の年」の範囲へ自動更新する
+    // （例: 2024 のファイルを編集すると 2024-2026 になる）。未変更ファイルは触らない。
+    ratchetFrom("origin/master")
+
+    // detekt と同様、当面は非ゲート（`check`/`build` を失敗させない）。開発者が任意に
+    // `./gradlew spotlessApply`（一括付与・更新）/ `spotlessCheck`（検証）を実行する運用とする。
+    // 将来 CI ゲート化する場合は isEnforceCheck=true にし、CI の checkout に fetch-depth: 0 を付ける
+    // （ratchetFrom が origin/master の履歴を必要とするため）。
+    isEnforceCheck = false
+
+    // ライセンスヘッダーは config/spotless/license-header.kt に一元管理し、$YEAR トークンで年を表す。
+    val licenseHeader = rootProject.file("config/spotless/license-header.kt")
+    kotlin {
+        target("src/**/*.kt")
+        licenseHeaderFile(licenseHeader)
+    }
+    kotlinGradle {
+        target("*.gradle.kts")
+        // .gradle.kts の最初の非ヘッダー行（build: import / settings: pluginManagement 等）を区切りとする。
+        licenseHeaderFile(licenseHeader, "(import|plugins|pluginManagement|dependencyResolutionManagement|rootProject|@file)")
+    }
 }
 
 tasks {

--- a/config/spotless/license-header.kt
+++ b/config/spotless/license-header.kt
@@ -1,0 +1,9 @@
+/*
+ * Written in $YEAR by Nikomaru <nikomaru@nikomaru.dev>
+ *
+ * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication along with this software.
+ * If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -46,6 +46,7 @@ shadow = { id = "com.gradleup.shadow", version = "9.4.3" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version = "2.4.0" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version = "2.4.0" }
 detekt = { id = "dev.detekt", version = "2.0.0-alpha.5" }
+spotless = { id = "com.diffplug.spotless", version = "7.0.2" }
 
 [bundles]
 commands = ["lamp-common", "lamp-bukkit"]

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/AdvanceRailway.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/AdvanceRailway.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/Line3D.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/Line3D.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/Point3D.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/Point3D.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/commands/CommandUtils.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/commands/CommandUtils.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/commands/FileCommand.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/commands/FileCommand.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/commands/GeneralCommand.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/commands/GeneralCommand.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/commands/group/GroupEditCommand.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/commands/group/GroupEditCommand.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/commands/group/GroupInfoCommand.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/commands/group/GroupInfoCommand.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/commands/group/GroupMainCommand.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/commands/group/GroupMainCommand.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/commands/railway/RailwayEditCommand.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/commands/railway/RailwayEditCommand.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/commands/railway/RailwayInfoCommand.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/commands/railway/RailwayInfoCommand.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/commands/railway/RailwayMainCommand.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/commands/railway/RailwayMainCommand.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/commands/railway/RailwayRouteCommand.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/commands/railway/RailwayRouteCommand.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/commands/station/StationEditCommand.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/commands/station/StationEditCommand.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/commands/station/StationInfoCommand.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/commands/station/StationInfoCommand.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/commands/station/StationMainCommand.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/commands/station/StationMainCommand.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/data/InspectData.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/data/InspectData.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/error/DataSearchError.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/error/DataSearchError.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/error/RailTraceError.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/error/RailTraceError.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/file/FileLoader.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/file/FileLoader.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/file/data/ConfigData.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/file/data/ConfigData.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/file/data/DataType.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/file/data/DataType.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/file/data/FileType.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/file/data/FileType.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/file/data/GroupData.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/file/data/GroupData.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/file/data/RailwayData.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/file/data/RailwayData.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/file/data/StationData.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/file/data/StationData.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/file/loader/ConfigDataLoader.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/file/loader/ConfigDataLoader.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/file/loader/RailwayDataLoader.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/file/loader/RailwayDataLoader.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/file/loader/StationDataLoader.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/file/loader/StationDataLoader.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/file/type/ExportFileType.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/file/type/ExportFileType.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/file/type/LineType.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/file/type/LineType.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/file/utils/AtomicFile.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/file/utils/AtomicFile.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/file/utils/Serializer.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/file/utils/Serializer.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/file/value/GroupId.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/file/value/GroupId.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/file/value/IdValidation.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/file/value/IdValidation.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/file/value/RailwayId.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/file/value/RailwayId.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/file/value/StationId.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/file/value/StationId.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/listener/RailClickEvent.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/listener/RailClickEvent.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/mineauth/MineAuthIntegration.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/mineauth/MineAuthIntegration.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/mineauth/RailwayApiHandler.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/mineauth/RailwayApiHandler.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/mineauth/dto/RailwayDtoMapper.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/mineauth/dto/RailwayDtoMapper.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/mineauth/dto/RailwayDtos.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/mineauth/dto/RailwayDtos.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/route/RouteFinder.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/route/RouteFinder.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/utils/GroupUtils.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/utils/GroupUtils.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/utils/RailwayUtils.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/utils/RailwayUtils.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/utils/StationUtils.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/utils/StationUtils.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/utils/Utils.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/utils/Utils.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/utils/command/GroupIdParser.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/utils/command/GroupIdParser.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/utils/command/IdParser.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/utils/command/IdParser.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/utils/command/Point3DParser.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/utils/command/Point3DParser.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/utils/command/RailwayIdParser.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/utils/command/RailwayIdParser.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/utils/command/StationIdParser.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/utils/command/StationIdParser.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/utils/command/ValueParser.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/utils/command/ValueParser.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/utils/coroutines/AsyncCoroutineDispatcher.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/utils/coroutines/AsyncCoroutineDispatcher.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/utils/coroutines/DispatcherContainer.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/utils/coroutines/DispatcherContainer.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/utils/coroutines/MinecraftCoroutineDispatcher.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/utils/coroutines/MinecraftCoroutineDispatcher.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/utils/coroutines/MinecraftCoroutineUtil.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/utils/coroutines/MinecraftCoroutineUtil.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/utils/display/DisplayLines.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/utils/display/DisplayLines.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/main/kotlin/dev/nikomaru/advancerailway/utils/display/LuminescenceShulker.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/utils/display/LuminescenceShulker.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/test/kotlin/dev/nikomaru/advancerailway/Line3DTest.kt
+++ b/src/test/kotlin/dev/nikomaru/advancerailway/Line3DTest.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/test/kotlin/dev/nikomaru/advancerailway/file/utils/SerializerTest.kt
+++ b/src/test/kotlin/dev/nikomaru/advancerailway/file/utils/SerializerTest.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/test/kotlin/dev/nikomaru/advancerailway/file/value/IdValidationTest.kt
+++ b/src/test/kotlin/dev/nikomaru/advancerailway/file/value/IdValidationTest.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/test/kotlin/dev/nikomaru/advancerailway/mineauth/RailwayApiHandlerTest.kt
+++ b/src/test/kotlin/dev/nikomaru/advancerailway/mineauth/RailwayApiHandlerTest.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/test/kotlin/dev/nikomaru/advancerailway/mineauth/dto/RailwayDtoMapperTest.kt
+++ b/src/test/kotlin/dev/nikomaru/advancerailway/mineauth/dto/RailwayDtoMapperTest.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/test/kotlin/dev/nikomaru/advancerailway/mineauth/dto/RailwayDtosTest.kt
+++ b/src/test/kotlin/dev/nikomaru/advancerailway/mineauth/dto/RailwayDtosTest.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/test/kotlin/dev/nikomaru/advancerailway/route/RouteFinderTest.kt
+++ b/src/test/kotlin/dev/nikomaru/advancerailway/route/RouteFinderTest.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *

--- a/src/test/kotlin/dev/nikomaru/advancerailway/utils/command/Point3DParserTest.kt
+++ b/src/test/kotlin/dev/nikomaru/advancerailway/utils/command/Point3DParserTest.kt
@@ -1,5 +1,5 @@
 /*
- * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
  *
  * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
  *


### PR DESCRIPTION
ライセンスヘッダーを1ファイルに集約し、Gradle（Spotless）で一括付与・更新できるようにします。年は `2024-{現在年}` の範囲へ自動更新します。

## 使い方

- `./gradlew spotlessApply` — 全ソースにヘッダーを一括付与／更新
- `./gradlew spotlessCheck` — ヘッダーの検証

ヘッダー本文は **`config/spotless/license-header.kt`** の1ファイルだけ編集すれば全体へ反映されます（`$YEAR` トークンで年を表現）。

## 年の自動更新

`ratchetFrom("origin/master")` により、**変更のあったファイルだけ**を対象にし、年を「元の年-現在年」の範囲へ更新します。

- 例: `2024` のファイルを編集して `spotlessApply` すると `2024-2026` になります。
- 未変更ファイルは触りません（無駄な全体書き換えを回避）。
- この PR では最初に処理される `build.gradle.kts` のヘッダーが `2024-2026` になっています。他ファイルは次に編集された時点で更新されます。

## 非ゲート運用

detekt が `ignoreFailures = true` で段階導入なのに合わせ、Spotless も当面**非ゲート**（`isEnforceCheck = false`）にしています。`build` / `check` は失敗させません。

将来 CI ゲート化する場合は `isEnforceCheck = true` にし、CI の `actions/checkout` に `fetch-depth: 0` を付けてください（`ratchetFrom` が `origin/master` の履歴を必要とするため）。

## 検証

- `./gradlew spotlessApply` / `spotlessCheck` / `build` すべて **BUILD SUCCESSFUL**（ローカルで実行確認済み）。
- `spotlessApply` が未変更の `.kt` を書き換えないこと（ratchet が効くこと）、および編集ファイルのヘッダー年が `2024-2026` になることを実ファイルで確認済み。
- ヘッダーと `package`/`import` の間の空行は従来スタイルどおり維持。

> [!NOTE]
> このPRは master 直系で、#145 / #147 とは独立です。