### PR TITLE
✨ 駅間の経路検索（レール＋徒歩・A*） (#146)

### DIFF
--- a/docs/docs/en/mineauth-api.md
+++ b/docs/docs/en/mineauth-api.md
@@ -131,9 +131,14 @@ All responses are JSON, encoded with `kotlinx.serialization`.
 `GET /route?from={id}&to={id}` computes the fastest (least total travel time) route between two stations.
 Both `from` and `to` are **required** query parameters; omitting either returns `400 Bad Request`.
 
-All railways are treated as a weighted **undirected** graph, with each railway's `timeRequired` (seconds)
-as the edge weight; the shortest path is found with Dijkstra's algorithm. Directional routing
-(`UP_LINE` / `DOWN_LINE`) is not yet distinguished.
+The network is modelled as a weighted graph with two kinds of edges, and the fastest path is found with
+A\* search:
+
+- **Rail edges** — each railway is an undirected edge weighted by its `timeRequired` (seconds).
+  Directional routing (`UP_LINE` / `DOWN_LINE`) is not yet distinguished.
+- **Walking edges** — any two stations **in the same world** are also connected by walking, weighted by
+  their straight-line horizontal distance ÷ the Minecraft walk speed (`4.317` blocks/s). This lets a route
+  reach stations that no railway connects. Stations in **different worlds** are only reachable via rail.
 
 ```json
 {
@@ -142,15 +147,19 @@ as the edge weight; the shortest path is found with Dijkstra's algorithm. Direct
   "totalTime": 150,
   "stations": ["central", "west", "north"],
   "legs": [
-    { "railway": "central-to-west", "from": "central", "to": "west", "timeRequired": 60, "group": "main-line" },
-    { "railway": "west-to-north", "from": "west", "to": "north", "timeRequired": 90, "group": null }
+    { "mode": "RAIL", "railway": "central-to-west", "from": "central", "to": "west", "timeRequired": 60, "group": "main-line" },
+    { "mode": "WALK", "railway": null, "from": "west", "to": "north", "timeRequired": 90, "group": null }
   ]
 }
 ```
 
+- `mode` is `"RAIL"` (riding a railway) or `"WALK"` (walking between stations).
+- `railway` and `group` are `null` on `WALK` legs (and `group` is `null` for a railway with no group).
 - `totalTime` is the sum of all legs' `timeRequired`, in seconds.
 - `stations` is the ordered list of station ids passed through, from `from` to `to`.
-- `group` on a leg may be `null` if that railway does not belong to a group.
+
+The command form `/ar railway route <to>` additionally supports routing from a player's current location,
+but the HTTP endpoint only accepts station ids.
 
 Error responses carry a machine-readable `code`:
 

--- a/docs/docs/en/mineauth-api.md
+++ b/docs/docs/en/mineauth-api.md
@@ -20,6 +20,7 @@ normally.
 | GET | `/railways/{id}` | Get a single railway by id |
 | GET | `/groups` | List all groups |
 | GET | `/groups/{id}` | Get a single group by id |
+| GET | `/route?from={id}&to={id}` | Find the fastest route between two stations |
 
 Paths above are relative to the `/api/v1/plugins/advancerailway/` base path, e.g. the full path for listing
 stations is `/api/v1/plugins/advancerailway/stations`.
@@ -28,7 +29,7 @@ A by-id request for an id that does not exist returns an HTTP `404 Not Found` er
 
 ## Authentication
 
-All six endpoints are declared `@Authenticated(callers = [CallerType.SERVICE])`, so they can only be
+All endpoints are declared `@Authenticated(callers = [CallerType.SERVICE])`, so they can only be
 called with a **service-account token** — a trusted credential that a server administrator issues via
 MineAuth. Player user tokens (issued through MineAuth's OAuth2 flow) are rejected. The endpoints expose
 exact in-world coordinates, so issue service tokens only to trusted backend integrations.
@@ -124,3 +125,37 @@ All responses are JSON, encoded with `kotlinx.serialization`.
 ```
 
 `GET /groups/{id}` returns a single group object (unwrapped).
+
+### Route
+
+`GET /route?from={id}&to={id}` computes the fastest (least total travel time) route between two stations.
+Both `from` and `to` are **required** query parameters; omitting either returns `400 Bad Request`.
+
+All railways are treated as a weighted **undirected** graph, with each railway's `timeRequired` (seconds)
+as the edge weight; the shortest path is found with Dijkstra's algorithm. Directional routing
+(`UP_LINE` / `DOWN_LINE`) is not yet distinguished.
+
+```json
+{
+  "from": "central",
+  "to": "north",
+  "totalTime": 150,
+  "stations": ["central", "west", "north"],
+  "legs": [
+    { "railway": "central-to-west", "from": "central", "to": "west", "timeRequired": 60, "group": "main-line" },
+    { "railway": "west-to-north", "from": "west", "to": "north", "timeRequired": 90, "group": null }
+  ]
+}
+```
+
+- `totalTime` is the sum of all legs' `timeRequired`, in seconds.
+- `stations` is the ordered list of station ids passed through, from `from` to `to`.
+- `group` on a leg may be `null` if that railway does not belong to a group.
+
+Error responses carry a machine-readable `code`:
+
+| Status | `code` | When |
+| --- | --- | --- |
+| `404 Not Found` | `station_not_found` | `from` or `to` is not a valid/existing station |
+| `400 Bad Request` | `same_station` | `from` and `to` are the same station |
+| `404 Not Found` | `no_route` | the two stations are not connected by any path |

--- a/docs/docs/ja/commands.md
+++ b/docs/docs/ja/commands.md
@@ -39,6 +39,7 @@
 - [x] `ar railway set to-station <railwayId> <toStation>` 路線の終点駅を変更します。
 - [x] `ar railway info <railwayId>` 路線の情報を表示します。
 - [x] `ar railway list` 路線の一覧を表示します。
+- [x] `ar railway route <from> <to>` 2駅間の最短（所要時間最小）経路を検索し、各区間と合計所要時間を表示します。
 
 ## 駅
 

--- a/docs/docs/ja/commands.md
+++ b/docs/docs/ja/commands.md
@@ -39,7 +39,8 @@
 - [x] `ar railway set to-station <railwayId> <toStation>` 路線の終点駅を変更します。
 - [x] `ar railway info <railwayId>` 路線の情報を表示します。
 - [x] `ar railway list` 路線の一覧を表示します。
-- [x] `ar railway route <from> <to>` 2駅間の最短（所要時間最小）経路を検索し、各区間と合計所要時間を表示します。
+- [x] `ar railway route <from> <to>` 2駅間の最短（所要時間最小）経路を検索し、各区間と合計所要時間を表示します。レール未接続の駅どうしは同一ワールド内であれば徒歩で補完します（A*探索）。
+- [x] `ar railway route <to>` プレイヤーの現在地から目的駅までの最短経路を検索します（現在地から徒歩＋レール）。
 
 ## 駅
 

--- a/src/main/kotlin/dev/nikomaru/advancerailway/AdvanceRailway.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/AdvanceRailway.kt
@@ -20,6 +20,7 @@ import dev.nikomaru.advancerailway.commands.group.GroupMainCommand
 import dev.nikomaru.advancerailway.commands.railway.RailwayEditCommand
 import dev.nikomaru.advancerailway.commands.railway.RailwayInfoCommand
 import dev.nikomaru.advancerailway.commands.railway.RailwayMainCommand
+import dev.nikomaru.advancerailway.commands.railway.RailwayRouteCommand
 import dev.nikomaru.advancerailway.commands.station.StationEditCommand
 import dev.nikomaru.advancerailway.commands.station.StationInfoCommand
 import dev.nikomaru.advancerailway.commands.station.StationMainCommand
@@ -128,6 +129,7 @@ open class AdvanceRailway: SuspendingJavaPlugin() {
             register(RailwayMainCommand())
             register(RailwayInfoCommand())
             register(RailwayEditCommand())
+            register(RailwayRouteCommand())
             register(StationMainCommand())
             register(StationInfoCommand())
             register(StationEditCommand())

--- a/src/main/kotlin/dev/nikomaru/advancerailway/commands/railway/RailwayRouteCommand.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/commands/railway/RailwayRouteCommand.kt
@@ -13,18 +13,24 @@ import arrow.core.Either
 import dev.nikomaru.advancerailway.AdvanceRailway
 import dev.nikomaru.advancerailway.commands.DataPaths
 import dev.nikomaru.advancerailway.commands.getOrSend
-import dev.nikomaru.advancerailway.file.data.RailwayData
+import dev.nikomaru.advancerailway.file.data.StationData
 import dev.nikomaru.advancerailway.file.value.IdValidation
 import dev.nikomaru.advancerailway.file.value.RailwayId
 import dev.nikomaru.advancerailway.file.value.StationId
+import dev.nikomaru.advancerailway.route.RailEdge
 import dev.nikomaru.advancerailway.route.Route
 import dev.nikomaru.advancerailway.route.RouteError
 import dev.nikomaru.advancerailway.route.RouteFinder
+import dev.nikomaru.advancerailway.route.StationNode
+import dev.nikomaru.advancerailway.route.TravelMode
+import dev.nikomaru.advancerailway.route.Waypoint
 import dev.nikomaru.advancerailway.utils.RailwayUtils
 import dev.nikomaru.advancerailway.utils.StationUtils
+import dev.nikomaru.advancerailway.utils.Utils.toPoint3D
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.bukkit.command.CommandSender
+import org.bukkit.entity.Player
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import revxrsal.commands.annotation.Command
@@ -34,57 +40,111 @@ import kotlin.math.ceil
 
 /**
  * 駅間の最短（所要時間最小）経路を求めて表示するコマンド。
- * `/ar railway route <from> <to>`
  *
- * 全路線データを重み付きグラフとして [RouteFinder] に渡し、経路の各区間と合計所要時間を表示する。
+ * - `/ar railway route <from> <to>` — 駅から駅。
+ * - `/ar railway route <to>` — プレイヤーの現在地から駅（プレイヤー専用）。
+ *
+ * 全路線（レール）と、同一ワールド内の徒歩移動を組み合わせた幾何グラフを [RouteFinder] に渡し、
+ * A* で最短経路を求める。レールでつながっていない駅どうしや現在地からでも徒歩で到達できる。
  */
 @Command("ar railway", "advancerailway railway")
 @CommandPermission("advancerailway.command.railway.read")
 class RailwayRouteCommand : KoinComponent {
     val plugin: AdvanceRailway by inject()
 
+    /** `/ar railway route <to>` — 現在地から。 */
+    @Subcommand("route")
+    suspend fun route(sender: CommandSender, to: StationId) {
+        val player = sender as? Player ?: run {
+            sender.sendRichMessage("<red>This form requires a player (uses your current location as the origin).")
+            return
+        }
+        val stations = loadAllStations()
+        val toNode = stations.find { it.id == to } ?: run {
+            sender.sendRichMessage("<red>Station not found: ${to.value}")
+            return
+        }
+        val origin = Waypoint.Origin(player.location.world.name, player.location.toPoint3D())
+        search(sender, stations, origin, toNode)
+    }
+
+    /** `/ar railway route <from> <to>` — 駅から駅。 */
     @Subcommand("route")
     suspend fun route(sender: CommandSender, from: StationId, to: StationId) {
-        // 出発駅・到着駅が実在することを先に確認する（存在しなければ経路探索より前に弾く）。
         StationUtils.getStationData(from).getOrSend(sender) { "Station not found: ${from.value}" } ?: return
         StationUtils.getStationData(to).getOrSend(sender) { "Station not found: ${to.value}" } ?: return
+        val stations = loadAllStations()
+        val fromNode = stations.find { it.id == from } ?: return
+        val toNode = stations.find { it.id == to } ?: return
+        search(sender, stations, Waypoint.Station(fromNode), toNode)
+    }
 
-        val edges = RouteFinder.buildEdges(loadAllRailways())
-        when (val result = RouteFinder.findRoute(edges, from, to)) {
+    private suspend fun search(
+        sender: CommandSender,
+        stations: List<StationNode>,
+        from: Waypoint,
+        to: StationNode,
+    ) {
+        val railways = loadAllRailways()
+        when (val result = RouteFinder.findRoute(stations, railways, from, to)) {
             is Either.Left -> when (result.value) {
                 RouteError.SameStation ->
                     sender.sendRichMessage("<red>Departure and destination are the same station.")
 
                 RouteError.NoPath ->
-                    sender.sendRichMessage("<red>No route found between ${from.value} and ${to.value}.")
+                    sender.sendRichMessage("<red>No route found to ${to.id.value}.")
             }
 
-            is Either.Right -> sendRoute(sender, result.value)
+            is Either.Right -> sendRoute(sender, from, result.value)
         }
     }
 
-    private fun sendRoute(sender: CommandSender, route: Route) {
+    private fun sendRoute(sender: CommandSender, from: Waypoint, route: Route) {
+        val origin = (from as? Waypoint.Station)?.node?.id?.value ?: "(current location)"
         sender.sendRichMessage(
-            "<green>Route: ${route.stations.first().value} -> ${route.stations.last().value} " +
+            "<green>Route: $origin -> ${route.legs.last().to.value} " +
                 "<gray>(${formatMinutes(route.totalSeconds)} min, ${route.legs.size} legs)"
         )
         route.legs.forEach { leg ->
-            val group = leg.group?.let { " <gray>[${it.value}]" } ?: ""
+            val fromLabel = leg.from?.value ?: "(current location)"
+            val via = when (leg.mode) {
+                TravelMode.RAIL -> {
+                    val group = leg.group?.let { " <gray>[${it.value}]" } ?: ""
+                    "<gray>via</gray> <click:run_command:/ar railway info ${leg.railwayId?.value}>" +
+                        "${leg.railwayId?.value}</click>$group"
+                }
+
+                TravelMode.WALK -> {
+                    "<gray>on foot"
+                }
+            }
             sender.sendRichMessage(
-                "<yellow> -> </yellow>${leg.from.value} → ${leg.to.value} " +
-                    "<gray>via</gray> <click:run_command:/ar railway info ${leg.railwayId.value}>" +
-                    "${leg.railwayId.value}</click>$group <gray>(${formatMinutes(leg.timeRequired)} min)"
+                "<yellow> -> </yellow>$fromLabel → ${leg.to.value} $via <gray>(${formatMinutes(leg.timeSeconds)} min)"
             )
         }
     }
 
-    /** data/railways/ 配下のすべての路線データを読み込む（壊れた/不正名のファイルは黙ってスキップ）。 */
-    private suspend fun loadAllRailways(): List<RailwayData> = withContext(Dispatchers.IO) {
-        val files = DataPaths.railways.listFiles()?.filter { it.isFile && it.extension == "json" } ?: return@withContext emptyList()
-        files.map { it.nameWithoutExtension }
-            .filter { IdValidation.isValid(it) }
-            .mapNotNull { RailwayUtils.getRailwayData(RailwayId(it)).getOrNull() }
+    /** data/stations/ 配下のすべての駅を幾何ノードとして読み込む。 */
+    private suspend fun loadAllStations(): List<StationNode> = withContext(Dispatchers.IO) {
+        listIds(DataPaths.stations)
+            .mapNotNull { StationUtils.getStationData(StationId(it)).getOrNull() }
+            .map { it.toNode() }
     }
+
+    /** data/railways/ 配下のすべての路線をレール辺として読み込む。 */
+    private suspend fun loadAllRailways(): List<RailEdge> = withContext(Dispatchers.IO) {
+        listIds(DataPaths.railways)
+            .mapNotNull { RailwayUtils.getRailwayData(RailwayId(it)).getOrNull() }
+            .map { RailEdge(it.id, it.fromStation, it.toStation, it.timeRequired, it.group) }
+    }
+
+    private fun listIds(folder: java.io.File): List<String> =
+        folder.listFiles()?.filter { it.isFile && it.extension == "json" }
+            ?.map { it.nameWithoutExtension }
+            ?.filter { IdValidation.isValid(it) }
+            ?: emptyList()
+
+    private fun StationData.toNode(): StationNode = StationNode(stationId, world.name, point)
 
     /** 秒を「小数第 1 位までの分」へ丸める（[RailwayInfoCommand] と同じ表記）。 */
     private fun formatMinutes(seconds: Long): Double = ceil(seconds / 6.0) / 10

--- a/src/main/kotlin/dev/nikomaru/advancerailway/commands/railway/RailwayRouteCommand.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/commands/railway/RailwayRouteCommand.kt
@@ -1,0 +1,91 @@
+/*
+ * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ *
+ * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication along with this software.
+ * If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+package dev.nikomaru.advancerailway.commands.railway
+
+import arrow.core.Either
+import dev.nikomaru.advancerailway.AdvanceRailway
+import dev.nikomaru.advancerailway.commands.DataPaths
+import dev.nikomaru.advancerailway.commands.getOrSend
+import dev.nikomaru.advancerailway.file.data.RailwayData
+import dev.nikomaru.advancerailway.file.value.IdValidation
+import dev.nikomaru.advancerailway.file.value.RailwayId
+import dev.nikomaru.advancerailway.file.value.StationId
+import dev.nikomaru.advancerailway.route.Route
+import dev.nikomaru.advancerailway.route.RouteError
+import dev.nikomaru.advancerailway.route.RouteFinder
+import dev.nikomaru.advancerailway.utils.RailwayUtils
+import dev.nikomaru.advancerailway.utils.StationUtils
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.bukkit.command.CommandSender
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import revxrsal.commands.annotation.Command
+import revxrsal.commands.annotation.Subcommand
+import revxrsal.commands.bukkit.annotation.CommandPermission
+import kotlin.math.ceil
+
+/**
+ * 駅間の最短（所要時間最小）経路を求めて表示するコマンド。
+ * `/ar railway route <from> <to>`
+ *
+ * 全路線データを重み付きグラフとして [RouteFinder] に渡し、経路の各区間と合計所要時間を表示する。
+ */
+@Command("ar railway", "advancerailway railway")
+@CommandPermission("advancerailway.command.railway.read")
+class RailwayRouteCommand : KoinComponent {
+    val plugin: AdvanceRailway by inject()
+
+    @Subcommand("route")
+    suspend fun route(sender: CommandSender, from: StationId, to: StationId) {
+        // 出発駅・到着駅が実在することを先に確認する（存在しなければ経路探索より前に弾く）。
+        StationUtils.getStationData(from).getOrSend(sender) { "Station not found: ${from.value}" } ?: return
+        StationUtils.getStationData(to).getOrSend(sender) { "Station not found: ${to.value}" } ?: return
+
+        val edges = RouteFinder.buildEdges(loadAllRailways())
+        when (val result = RouteFinder.findRoute(edges, from, to)) {
+            is Either.Left -> when (result.value) {
+                RouteError.SameStation ->
+                    sender.sendRichMessage("<red>Departure and destination are the same station.")
+
+                RouteError.NoPath ->
+                    sender.sendRichMessage("<red>No route found between ${from.value} and ${to.value}.")
+            }
+
+            is Either.Right -> sendRoute(sender, result.value)
+        }
+    }
+
+    private fun sendRoute(sender: CommandSender, route: Route) {
+        sender.sendRichMessage(
+            "<green>Route: ${route.stations.first().value} -> ${route.stations.last().value} " +
+                "<gray>(${formatMinutes(route.totalSeconds)} min, ${route.legs.size} legs)"
+        )
+        route.legs.forEach { leg ->
+            val group = leg.group?.let { " <gray>[${it.value}]" } ?: ""
+            sender.sendRichMessage(
+                "<yellow> -> </yellow>${leg.from.value} → ${leg.to.value} " +
+                    "<gray>via</gray> <click:run_command:/ar railway info ${leg.railwayId.value}>" +
+                    "${leg.railwayId.value}</click>$group <gray>(${formatMinutes(leg.timeRequired)} min)"
+            )
+        }
+    }
+
+    /** data/railways/ 配下のすべての路線データを読み込む（壊れた/不正名のファイルは黙ってスキップ）。 */
+    private suspend fun loadAllRailways(): List<RailwayData> = withContext(Dispatchers.IO) {
+        val files = DataPaths.railways.listFiles()?.filter { it.isFile && it.extension == "json" } ?: return@withContext emptyList()
+        files.map { it.nameWithoutExtension }
+            .filter { IdValidation.isValid(it) }
+            .mapNotNull { RailwayUtils.getRailwayData(RailwayId(it)).getOrNull() }
+    }
+
+    /** 秒を「小数第 1 位までの分」へ丸める（[RailwayInfoCommand] と同じ表記）。 */
+    private fun formatMinutes(seconds: Long): Double = ceil(seconds / 6.0) / 10
+}

--- a/src/main/kotlin/dev/nikomaru/advancerailway/commands/railway/RailwayRouteCommand.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/commands/railway/RailwayRouteCommand.kt
@@ -11,8 +11,6 @@ package dev.nikomaru.advancerailway.commands.railway
 
 import arrow.core.Either
 import dev.nikomaru.advancerailway.AdvanceRailway
-import dev.nikomaru.advancerailway.commands.DataPaths
-import dev.nikomaru.advancerailway.commands.getOrSend
 import dev.nikomaru.advancerailway.file.data.StationData
 import dev.nikomaru.advancerailway.file.value.IdValidation
 import dev.nikomaru.advancerailway.file.value.RailwayId
@@ -34,6 +32,7 @@ import org.bukkit.entity.Player
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 import revxrsal.commands.annotation.Command
+import revxrsal.commands.annotation.Optional
 import revxrsal.commands.annotation.Subcommand
 import revxrsal.commands.bukkit.annotation.CommandPermission
 import kotlin.math.ceil
@@ -52,31 +51,43 @@ import kotlin.math.ceil
 class RailwayRouteCommand : KoinComponent {
     val plugin: AdvanceRailway by inject()
 
-    /** `/ar railway route <to>` — 現在地から。 */
+    /**
+     * 経路検索。
+     * - `/ar railway route <to>` — プレイヤーの現在地から `to` へ（プレイヤー専用）。
+     * - `/ar railway route <from> <to>` — 駅 `from` から駅 `to` へ。
+     *
+     * 引数が 1 つのときは末尾省略として現在地を起点にする（[second] が null）。
+     * 2 つのときは `first` を出発駅、[second] を到着駅として扱う。
+     * revxrsal Lamp 3.x は同名サブコマンドのアリティ多重定義を許さないため、
+     * 末尾 [Optional] 引数 1 つで両形式を受ける。
+     */
     @Subcommand("route")
-    suspend fun route(sender: CommandSender, to: StationId) {
-        val player = sender as? Player ?: run {
-            sender.sendRichMessage("<red>This form requires a player (uses your current location as the origin).")
-            return
-        }
+    suspend fun route(sender: CommandSender, first: StationId, @Optional second: StationId? = null) {
         val stations = loadAllStations()
-        val toNode = stations.find { it.id == to } ?: run {
-            sender.sendRichMessage("<red>Station not found: ${to.value}")
-            return
+        if (second == null) {
+            // route <to>: 現在地から first へ。
+            val player = sender as? Player ?: run {
+                sender.sendRichMessage("<red>This form requires a player (uses your current location as the origin).")
+                return
+            }
+            val toNode = stations.find { it.id == first } ?: run {
+                sender.sendRichMessage("<red>Station not found: ${first.value}")
+                return
+            }
+            val origin = Waypoint.Origin(player.location.world.name, player.location.toPoint3D())
+            search(sender, stations, origin, toNode)
+        } else {
+            // route <from> <to>: 駅から駅へ。
+            val fromNode = stations.find { it.id == first } ?: run {
+                sender.sendRichMessage("<red>Station not found: ${first.value}")
+                return
+            }
+            val toNode = stations.find { it.id == second } ?: run {
+                sender.sendRichMessage("<red>Station not found: ${second.value}")
+                return
+            }
+            search(sender, stations, Waypoint.Station(fromNode), toNode)
         }
-        val origin = Waypoint.Origin(player.location.world.name, player.location.toPoint3D())
-        search(sender, stations, origin, toNode)
-    }
-
-    /** `/ar railway route <from> <to>` — 駅から駅。 */
-    @Subcommand("route")
-    suspend fun route(sender: CommandSender, from: StationId, to: StationId) {
-        StationUtils.getStationData(from).getOrSend(sender) { "Station not found: ${from.value}" } ?: return
-        StationUtils.getStationData(to).getOrSend(sender) { "Station not found: ${to.value}" } ?: return
-        val stations = loadAllStations()
-        val fromNode = stations.find { it.id == from } ?: return
-        val toNode = stations.find { it.id == to } ?: return
-        search(sender, stations, Waypoint.Station(fromNode), toNode)
     }
 
     private suspend fun search(
@@ -126,20 +137,22 @@ class RailwayRouteCommand : KoinComponent {
 
     /** data/stations/ 配下のすべての駅を幾何ノードとして読み込む。 */
     private suspend fun loadAllStations(): List<StationNode> = withContext(Dispatchers.IO) {
-        listIds(DataPaths.stations)
+        listIds("stations")
             .mapNotNull { StationUtils.getStationData(StationId(it)).getOrNull() }
             .map { it.toNode() }
     }
 
     /** data/railways/ 配下のすべての路線をレール辺として読み込む。 */
     private suspend fun loadAllRailways(): List<RailEdge> = withContext(Dispatchers.IO) {
-        listIds(DataPaths.railways)
+        listIds("railways")
             .mapNotNull { RailwayUtils.getRailwayData(RailwayId(it)).getOrNull() }
             .map { RailEdge(it.id, it.fromStation, it.toStation, it.timeRequired, it.group) }
     }
 
-    private fun listIds(folder: java.io.File): List<String> =
-        folder.listFiles()?.filter { it.isFile && it.extension == "json" }
+    /** data/{type}/ 配下の JSON ファイル名を、allowlist を満たす ID として列挙する。 */
+    private fun listIds(type: String): List<String> =
+        plugin.dataFolder.resolve("data").resolve(type).listFiles()
+            ?.filter { it.isFile && it.extension == "json" }
             ?.map { it.nameWithoutExtension }
             ?.filter { IdValidation.isValid(it) }
             ?: emptyList()

--- a/src/main/kotlin/dev/nikomaru/advancerailway/mineauth/RailwayApiHandler.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/mineauth/RailwayApiHandler.kt
@@ -244,6 +244,8 @@ class RailwayApiHandler : KoinComponent {
         folder.listFiles(File::isFile)
             ?.filter { it.extension == "json" }
             ?.map { it.nameWithoutExtension }
+            // 不正なファイル名（allowlist 外）を除外し、value class の init で例外→500 になるのを防ぐ。
+            ?.filter { IdValidation.isValid(it) }
             ?.sorted()
             ?: emptyList()
     }

--- a/src/main/kotlin/dev/nikomaru/advancerailway/mineauth/RailwayApiHandler.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/mineauth/RailwayApiHandler.kt
@@ -26,9 +26,12 @@ import dev.nikomaru.advancerailway.mineauth.dto.RouteLegDto
 import dev.nikomaru.advancerailway.mineauth.dto.RouteResponse
 import dev.nikomaru.advancerailway.mineauth.dto.StationDto
 import dev.nikomaru.advancerailway.mineauth.dto.StationsResponse
+import dev.nikomaru.advancerailway.route.RailEdge
 import dev.nikomaru.advancerailway.route.Route
 import dev.nikomaru.advancerailway.route.RouteError
 import dev.nikomaru.advancerailway.route.RouteFinder
+import dev.nikomaru.advancerailway.route.StationNode
+import dev.nikomaru.advancerailway.route.Waypoint
 import dev.nikomaru.advancerailway.utils.GroupUtils
 import dev.nikomaru.advancerailway.utils.RailwayUtils
 import dev.nikomaru.advancerailway.utils.StationUtils
@@ -194,12 +197,13 @@ class RailwayApiHandler : KoinComponent {
         @Query("from") from: String,
         @Query("to") to: String,
     ): RouteResponse {
-        val fromId = requireStation(from)
-        val toId = requireStation(to)
+        val stations = loadStationNodes()
+        val fromNode = requireStation(from, stations)
+        val toNode = requireStation(to, stations)
         val railways = listIds("railways")
             .mapNotNull { RailwayUtils.getRailwayData(RailwayId(it)).getOrNull() }
-        val edges = RouteFinder.buildEdges(railways)
-        return when (val result = RouteFinder.findRoute(edges, fromId, toId)) {
+            .map { RailEdge(it.id, it.fromStation, it.toStation, it.timeRequired, it.group) }
+        return when (val result = RouteFinder.findRoute(stations, railways, Waypoint.Station(fromNode), toNode)) {
             is Either.Left -> when (result.value) {
                 RouteError.SameStation -> throw HttpError(
                     HttpStatus.BAD_REQUEST, "Departure and destination are the same station", code = "same_station"
@@ -210,22 +214,25 @@ class RailwayApiHandler : KoinComponent {
                 )
             }
 
-            is Either.Right -> result.value.toDto(fromId, toId)
+            is Either.Right -> result.value.toDto(fromNode.id, toNode.id)
         }
     }
 
+    /** 経路探索用に、全駅を幾何ノードとして読み込む。 */
+    private suspend fun loadStationNodes(): List<StationNode> = listIds("stations")
+        .mapNotNull { StationUtils.getStationData(StationId(it)).getOrNull() }
+        .map { StationNode(it.stationId, it.world.name, it.point) }
+
     /**
-     * 経路探索用に駅 ID を検証・解決する。
+     * 経路探索用に駅 ID を検証し、読み込み済みノードから解決する。
      * 不正な ID または存在しない駅は 404 `station_not_found` として弾く。
      */
-    private suspend fun requireStation(id: String): StationId {
+    private fun requireStation(id: String, stations: List<StationNode>): StationNode {
         if (!IdValidation.isValid(id)) {
             throw HttpError(HttpStatus.NOT_FOUND, "Station not found: $id", code = "station_not_found")
         }
-        val stationId = StationId(id)
-        StationUtils.getStationData(stationId).getOrNull()
+        return stations.find { it.id.value == id }
             ?: throw HttpError(HttpStatus.NOT_FOUND, "Station not found: $id", code = "station_not_found")
-        return stationId
     }
 
     /**
@@ -277,10 +284,11 @@ class RailwayApiHandler : KoinComponent {
         stations = stations.map { it.value },
         legs = legs.map {
             RouteLegDto(
-                railway = it.railwayId.value,
-                from = it.from.value,
+                mode = it.mode.name,
+                railway = it.railwayId?.value,
+                from = it.from?.value,
                 to = it.to.value,
-                timeRequired = it.timeRequired,
+                timeRequired = it.timeSeconds,
                 group = it.group?.value,
             )
         },

--- a/src/main/kotlin/dev/nikomaru/advancerailway/mineauth/RailwayApiHandler.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/mineauth/RailwayApiHandler.kt
@@ -22,11 +22,17 @@ import dev.nikomaru.advancerailway.mineauth.dto.GroupsResponse
 import dev.nikomaru.advancerailway.mineauth.dto.RailwayDto
 import dev.nikomaru.advancerailway.mineauth.dto.RailwayDtoMapper
 import dev.nikomaru.advancerailway.mineauth.dto.RailwaysResponse
+import dev.nikomaru.advancerailway.mineauth.dto.RouteLegDto
+import dev.nikomaru.advancerailway.mineauth.dto.RouteResponse
 import dev.nikomaru.advancerailway.mineauth.dto.StationDto
 import dev.nikomaru.advancerailway.mineauth.dto.StationsResponse
+import dev.nikomaru.advancerailway.route.Route
+import dev.nikomaru.advancerailway.route.RouteError
+import dev.nikomaru.advancerailway.route.RouteFinder
 import dev.nikomaru.advancerailway.utils.GroupUtils
 import dev.nikomaru.advancerailway.utils.RailwayUtils
 import dev.nikomaru.advancerailway.utils.StationUtils
+import arrow.core.Either
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.koin.core.component.KoinComponent
@@ -174,6 +180,55 @@ class RailwayApiHandler : KoinComponent {
     }
 
     /**
+     * 2 駅間の最短（所要時間最小）経路を求める。
+     * GET /route?from={stationId}&to={stationId}
+     *
+     * 全路線を重み付き無向グラフとみなし、[RouteFinder] で経路を探索する。
+     * - 駅が存在しない: 404 `station_not_found`
+     * - 出発駅と到着駅が同一: 400 `same_station`
+     * - 経路が存在しない: 404 `no_route`
+     */
+    @Get("/route")
+    @Authenticated(callers = [CallerType.SERVICE])
+    suspend fun getRoute(
+        @Query("from") from: String,
+        @Query("to") to: String,
+    ): RouteResponse {
+        val fromId = requireStation(from)
+        val toId = requireStation(to)
+        val railways = listIds("railways")
+            .mapNotNull { RailwayUtils.getRailwayData(RailwayId(it)).getOrNull() }
+        val edges = RouteFinder.buildEdges(railways)
+        return when (val result = RouteFinder.findRoute(edges, fromId, toId)) {
+            is Either.Left -> when (result.value) {
+                RouteError.SameStation -> throw HttpError(
+                    HttpStatus.BAD_REQUEST, "Departure and destination are the same station", code = "same_station"
+                )
+
+                RouteError.NoPath -> throw HttpError(
+                    HttpStatus.NOT_FOUND, "No route between $from and $to", code = "no_route"
+                )
+            }
+
+            is Either.Right -> result.value.toDto(fromId, toId)
+        }
+    }
+
+    /**
+     * 経路探索用に駅 ID を検証・解決する。
+     * 不正な ID または存在しない駅は 404 `station_not_found` として弾く。
+     */
+    private suspend fun requireStation(id: String): StationId {
+        if (!IdValidation.isValid(id)) {
+            throw HttpError(HttpStatus.NOT_FOUND, "Station not found: $id", code = "station_not_found")
+        }
+        val stationId = StationId(id)
+        StationUtils.getStationData(stationId).getOrNull()
+            ?: throw HttpError(HttpStatus.NOT_FOUND, "Station not found: $id", code = "station_not_found")
+        return stationId
+    }
+
+    /**
      * data/{type}/ 配下の JSON ファイル名（拡張子なし）を ID として列挙する。
      */
     private suspend fun listIds(type: String): List<String> = withContext(Dispatchers.IO) {
@@ -213,5 +268,21 @@ class RailwayApiHandler : KoinComponent {
         id = groupId.value,
         name = name,
         color = RailwayDtoMapper.colorToHex(railwayColor),
+    )
+
+    private fun Route.toDto(from: StationId, to: StationId): RouteResponse = RouteResponse(
+        from = from.value,
+        to = to.value,
+        totalTime = totalSeconds,
+        stations = stations.map { it.value },
+        legs = legs.map {
+            RouteLegDto(
+                railway = it.railwayId.value,
+                from = it.from.value,
+                to = it.to.value,
+                timeRequired = it.timeRequired,
+                group = it.group?.value,
+            )
+        },
     )
 }

--- a/src/main/kotlin/dev/nikomaru/advancerailway/mineauth/dto/RailwayDtos.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/mineauth/dto/RailwayDtos.kt
@@ -78,15 +78,20 @@ data class RailwaysResponse(val railways: List<RailwayDto>)
 @Serializable
 data class GroupsResponse(val groups: List<GroupDto>)
 
-/** 経路の 1 区間（1 本の路線に乗る単位）。 */
+/** 経路の 1 区間。レール乗車または徒歩移動の単位。 */
 @Serializable
 data class RouteLegDto(
-    val railway: String,
-    val from: String,
+    /** 移動手段。`"RAIL"`（路線）または `"WALK"`（徒歩）。 */
+    val mode: String,
+    /** レール区間で乗る路線。徒歩区間では `null`。 */
+    val railway: String?,
+    /** 区間の出発駅。起点が現在地の場合は `null`。 */
+    val from: String?,
+    /** 区間の到着駅。 */
     val to: String,
     /** この区間の所要時間（秒）。 */
     val timeRequired: Long,
-    /** 路線が属するグループ。無ければ `null`。 */
+    /** 路線が属するグループ。徒歩区間や無所属の場合は `null`。 */
     val group: String?,
 )
 

--- a/src/main/kotlin/dev/nikomaru/advancerailway/mineauth/dto/RailwayDtos.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/mineauth/dto/RailwayDtos.kt
@@ -77,3 +77,27 @@ data class RailwaysResponse(val railways: List<RailwayDto>)
 /** グループ一覧レスポンス。 */
 @Serializable
 data class GroupsResponse(val groups: List<GroupDto>)
+
+/** 経路の 1 区間（1 本の路線に乗る単位）。 */
+@Serializable
+data class RouteLegDto(
+    val railway: String,
+    val from: String,
+    val to: String,
+    /** この区間の所要時間（秒）。 */
+    val timeRequired: Long,
+    /** 路線が属するグループ。無ければ `null`。 */
+    val group: String?,
+)
+
+/** 駅間経路レスポンス。 */
+@Serializable
+data class RouteResponse(
+    val from: String,
+    val to: String,
+    /** 合計所要時間（秒）。 */
+    val totalTime: Long,
+    /** 出発駅から到着駅まで、通過順に並んだ駅 ID 列。 */
+    val stations: List<String>,
+    val legs: List<RouteLegDto>,
+)

--- a/src/main/kotlin/dev/nikomaru/advancerailway/route/RouteFinder.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/route/RouteFinder.kt
@@ -120,14 +120,18 @@ object RouteFinder {
 
     private data class Node(val key: String, val stationId: StationId?, val world: String, val point: Point3D)
 
-    /** ノードへ入る辺の記録（経路復元用）。 */
+    /**
+     * ノードへ入る辺の記録（経路復元用）。
+     * [cost] は丸め前の秒（実数）で、A* の探索と許容ヒューリスティックの整合のために用いる。
+     * 表示用の整数秒は復元時に [cost] を丸めて求める。
+     */
     private data class Incoming(
         val fromKey: String,
         val mode: TravelMode,
         val railwayId: RailwayId?,
         val fromStation: StationId?,
         val toStation: StationId,
-        val timeSeconds: Long,
+        val cost: Double,
         val group: GroupId?,
     )
 
@@ -177,9 +181,9 @@ object RouteFinder {
             val current = nodeByKey.getValue(key)
             val baseG = gScore.getValue(key)
 
-            for ((neighbor, incomingEdge) in neighbors(current, stationNodes, railAdjacency, walkSpeed)) {
+            for ((neighbor, incomingEdge) in neighbors(current, stationNodes, nodeByKey, railAdjacency, walkSpeed)) {
                 if (neighbor.key in settled) continue
-                val tentative = baseG + incomingEdge.timeSeconds
+                val tentative = baseG + incomingEdge.cost
                 if (tentative < (gScore[neighbor.key] ?: Double.MAX_VALUE)) {
                     gScore[neighbor.key] = tentative
                     incoming[neighbor.key] = incomingEdge
@@ -190,13 +194,13 @@ object RouteFinder {
 
         if (goalNode.key !in gScore) return RouteError.NoPath.left()
 
-        // 終点から起点へ辿って経路を復元する。
+        // 終点から起点へ辿って経路を復元する。表示用の整数秒はここで各区間の実数コストを丸めて求める。
         val legs = ArrayDeque<RouteLeg>()
         var cursor = goalNode.key
         while (cursor != fromNode.key) {
             val edge = incoming[cursor] ?: return RouteError.NoPath.left()
             legs.addFirst(
-                RouteLeg(edge.mode, edge.railwayId, edge.fromStation, edge.toStation, edge.timeSeconds, edge.group)
+                RouteLeg(edge.mode, edge.railwayId, edge.fromStation, edge.toStation, edge.cost.roundToLong(), edge.group)
             )
             cursor = edge.fromKey
         }
@@ -212,27 +216,31 @@ object RouteFinder {
             )
         }.groupBy { it.from.value }
 
-    /** [current] から出る辺（レール + 同一ワールドの徒歩）を、A* の重み（秒）は非負の実数で列挙する。 */
+    /**
+     * [current] から出る辺（レール + 同一ワールドの徒歩）を列挙する。
+     * A* の重み [Incoming.cost] は丸め前の秒（実数）とし、ヒューリスティックとの整合を保つ。
+     * [nodeByKey] はレール辺の到達駅解決に用いる（呼び出しごとに再構築しないよう外から渡す）。
+     */
     private fun neighbors(
         current: Node,
         stationNodes: List<Node>,
+        nodeByKey: Map<String, Node>,
         railAdjacency: Map<String, List<RailEdge>>,
         walkSpeed: Double,
     ): List<Pair<Node, Incoming>> {
         val result = ArrayList<Pair<Node, Incoming>>()
-        val stationByKey = stationNodes.associateBy { it.key }
 
         // レール辺（起点が駅のときのみ）。
         current.stationId?.let { fromId ->
             for (edge in railAdjacency[current.key].orEmpty()) {
-                val neighbor = stationByKey[edge.to.value] ?: continue
+                val neighbor = nodeByKey[edge.to.value] ?: continue
                 result += neighbor to Incoming(
                     fromKey = current.key,
                     mode = TravelMode.RAIL,
                     railwayId = edge.railwayId,
                     fromStation = fromId,
                     toStation = edge.to,
-                    timeSeconds = edge.timeRequired,
+                    cost = edge.timeRequired.toDouble(),
                     group = edge.group,
                 )
             }
@@ -242,14 +250,13 @@ object RouteFinder {
         for (neighbor in stationNodes) {
             if (neighbor.key == current.key) continue
             if (neighbor.world != current.world) continue
-            val walkSeconds = (current.point.distanceTo2D(neighbor.point) / walkSpeed).roundToLong()
             result += neighbor to Incoming(
                 fromKey = current.key,
                 mode = TravelMode.WALK,
                 railwayId = null,
                 fromStation = current.stationId,
                 toStation = neighbor.stationId!!, // stationNodes は必ず駅。
-                timeSeconds = walkSeconds,
+                cost = current.point.distanceTo2D(neighbor.point) / walkSpeed,
                 group = null,
             )
         }

--- a/src/main/kotlin/dev/nikomaru/advancerailway/route/RouteFinder.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/route/RouteFinder.kt
@@ -12,17 +12,23 @@ package dev.nikomaru.advancerailway.route
 import arrow.core.Either
 import arrow.core.left
 import arrow.core.right
-import dev.nikomaru.advancerailway.file.data.RailwayData
+import dev.nikomaru.advancerailway.Point3D
 import dev.nikomaru.advancerailway.file.value.GroupId
 import dev.nikomaru.advancerailway.file.value.RailwayId
 import dev.nikomaru.advancerailway.file.value.StationId
 import java.util.PriorityQueue
+import kotlin.math.roundToLong
 
-/**
- * ネットワークグラフ上の 1 本の有向辺。
- * 駅 [from] から駅 [to] へ、路線 [railwayId] を [timeRequired] 秒で結ぶ。
- */
-data class RouteEdge(
+/** グラフ上のノードとなる駅（幾何情報つき）。 */
+data class StationNode(
+    val id: StationId,
+    /** 駅の存在するワールド名（徒歩接続の同一ワールド判定に使う）。 */
+    val world: String,
+    val point: Point3D,
+)
+
+/** 2 駅を結ぶ路線（無向のレール辺）。 */
+data class RailEdge(
     val railwayId: RailwayId,
     val from: StationId,
     val to: StationId,
@@ -30,27 +36,56 @@ data class RouteEdge(
     val group: GroupId?,
 )
 
-/** 求めた経路の 1 区間（1 本の路線に乗る単位）。 */
+/** 経路の起点。駅、またはプレイヤーの現在地。 */
+sealed interface Waypoint {
+    val world: String
+    val point: Point3D
+
+    /** 既存の駅を起点とする。 */
+    data class Station(val node: StationNode) : Waypoint {
+        override val world: String get() = node.world
+        override val point: Point3D get() = node.point
+    }
+
+    /** プレイヤーの現在地を起点とする（駅 ID を持たない）。 */
+    data class Origin(override val world: String, override val point: Point3D) : Waypoint
+}
+
+/** 経路の各区間の移動手段。 */
+enum class TravelMode {
+    /** 路線（レール）に乗る。 */
+    RAIL,
+
+    /** 駅・現在地の間を歩く。 */
+    WALK,
+}
+
+/** 求めた経路の 1 区間。 */
 data class RouteLeg(
-    val railwayId: RailwayId,
-    val from: StationId,
+    val mode: TravelMode,
+    /** [TravelMode.RAIL] のとき乗る路線。[TravelMode.WALK] では `null`。 */
+    val railwayId: RailwayId?,
+    /** 区間の出発駅。起点が現在地の場合は `null`。 */
+    val from: StationId?,
+    /** 区間の到着駅（中間・終点は常に駅）。 */
     val to: StationId,
-    val timeRequired: Long,
+    /** この区間の所要時間（秒）。 */
+    val timeSeconds: Long,
     val group: GroupId?,
 )
 
-/** 出発駅から到着駅までの経路探索結果。 */
+/** 経路探索結果。 */
 data class Route(
     val legs: List<RouteLeg>,
-    /**
-     * 合計所要時間（秒）。
-     * 区間ごとに分へ丸めてから合算すると誤差が積み上がるため、生の秒で合算した値を保持する。
-     */
+    /** 合計所要時間（秒）。表示と一致するよう、各区間の丸め済み秒の総和とする。 */
     val totalSeconds: Long,
 ) {
-    /** 出発駅から到着駅まで、通過順に並んだ駅列。 */
+    /** 起点（現在地は除く）から終点まで、通過順に並んだ駅列。 */
     val stations: List<StationId>
-        get() = if (legs.isEmpty()) emptyList() else listOf(legs.first().from) + legs.map { it.to }
+        get() = if (legs.isEmpty()) emptyList() else buildList {
+            legs.first().from?.let { add(it) }
+            legs.forEach { add(it.to) }
+        }
 }
 
 /** 経路を返せなかった理由。 */
@@ -58,77 +93,189 @@ sealed interface RouteError {
     /** 出発駅と到着駅が同一。 */
     data object SameStation : RouteError
 
-    /** 出発駅と到着駅の間に経路が存在しない（未接続 / 孤立駅）。 */
+    /** 経路が存在しない（異なるワールド間で、それらを結ぶレール経路も無い）。 */
     data object NoPath : RouteError
 }
 
 /**
- * 路線データを重み付きグラフとみなし、駅間の最短（所要時間最小）経路を求める純粋ロジック。
+ * 路線（レール）と徒歩を組み合わせた幾何グラフ上で、駅間の最短（所要時間最小）経路を A* で求める純粋ロジック。
  *
- * Bukkit / Koin に依存せず、[RouteEdge] のリストと [StationId] のみで完結するため、
- * サーバーを起動しなくても単体テストできる（[dev.nikomaru.advancerailway.mineauth.dto.RailwayDtoMapper]
- * と同じ「サーバー非依存の純粋ロジックを切り出す」方針）。
+ * - **レール辺**: 各路線を無向辺とし、重みは [RailEdge.timeRequired]（秒）。
+ * - **徒歩辺**: 同一ワールドの任意のノード間を直線水平距離（[Point3D.distanceTo2D]）÷ [walkSpeed] 秒で結ぶ。
+ *   これにより、レールで直接つながっていない駅どうしや現在地からでも「歩いて」到達できる。
+ *   異なるワールド間は徒歩不可（座標系が異なるため）。
+ *
+ * ヒューリスティックは「終点までの直線距離 ÷ グラフ内の最大移動速度」。どの辺も
+ * 「直線変位 ÷ 最大速度」より速くは進めないため許容的（admissible）であり、A* は最短経路を保証する。
+ *
+ * Bukkit / Koin に依存せず [Point3D] とワールド名（文字列）のみで完結するため、サーバー非依存で単体テストできる。
  */
 object RouteFinder {
 
-    /**
-     * すべての [RailwayData] からグラフの辺集合を構築する。
-     *
-     * v1 では路線を**無向辺**として扱い、各路線につき両方向の [RouteEdge] を張る。
-     * [dev.nikomaru.advancerailway.file.type.LineType] による方向別ルーティング
-     * （UP_LINE / DOWN_LINE の区別）は、既存データがすべて UP_DOWN_LINE であり
-     * from/to の意味が確定していないため、将来対応とする。
-     */
-    fun buildEdges(railways: List<RailwayData>): List<RouteEdge> = railways.flatMap { railway ->
-        listOf(
-            RouteEdge(railway.id, railway.fromStation, railway.toStation, railway.timeRequired, railway.group),
-            RouteEdge(railway.id, railway.toStation, railway.fromStation, railway.timeRequired, railway.group),
-        )
-    }
+    /** Minecraft の既定の歩行速度（ブロック / 秒）。 */
+    const val DEFAULT_WALK_SPEED: Double = 4.317
+
+    /** 現在地ノードの内部キー。ID の allowlist（`[A-Za-z0-9_-]`）に含まれない文字を使い駅と衝突させない。 */
+    private const val ORIGIN_KEY = "@origin"
+
+    private data class Node(val key: String, val stationId: StationId?, val world: String, val point: Point3D)
+
+    /** ノードへ入る辺の記録（経路復元用）。 */
+    private data class Incoming(
+        val fromKey: String,
+        val mode: TravelMode,
+        val railwayId: RailwayId?,
+        val fromStation: StationId?,
+        val toStation: StationId,
+        val timeSeconds: Long,
+        val group: GroupId?,
+    )
 
     /**
-     * [from] から [to] までの、所要時間が最小となる経路を Dijkstra 法で求める。
+     * [from] から駅 [to] までの最短経路を求める。
      *
-     * [timeRequired]（秒、非負）を辺の重みとする。駅の存在確認は行わない
-     * （呼び出し側が事前に検証する想定）。到達不能な場合は [RouteError.NoPath] を返す。
-     *
-     * @return 最短経路、または探索に失敗した理由。
+     * @param stations グラフに含める全駅（幾何情報つき）。[to] もこの中に含まれていること。
+     * @param railways 全路線（レール辺）。
+     * @param from 起点（駅または現在地）。
+     * @param to 終点となる駅。
+     * @param walkSpeed 歩行速度（ブロック / 秒）。
      */
-    fun findRoute(edges: List<RouteEdge>, from: StationId, to: StationId): Either<RouteError, Route> {
-        if (from == to) return RouteError.SameStation.left()
+    fun findRoute(
+        stations: List<StationNode>,
+        railways: List<RailEdge>,
+        from: Waypoint,
+        to: StationNode,
+        walkSpeed: Double = DEFAULT_WALK_SPEED,
+    ): Either<RouteError, Route> {
+        val fromStationId = (from as? Waypoint.Station)?.node?.id
+        if (fromStationId != null && fromStationId == to.id) return RouteError.SameStation.left()
 
-        val adjacency: Map<StationId, List<RouteEdge>> = edges.groupBy { it.from }
-        val distance = HashMap<StationId, Long>().apply { put(from, 0L) }
-        val incomingEdge = HashMap<StationId, RouteEdge>()
-        val settled = HashSet<StationId>()
-        val queue = PriorityQueue<Pair<StationId, Long>>(compareBy { it.second })
-        queue.add(from to 0L)
+        val fromNode = when (from) {
+            is Waypoint.Station -> Node(from.node.id.value, from.node.id, from.world, from.point)
+            is Waypoint.Origin -> Node(ORIGIN_KEY, null, from.world, from.point)
+        }
+        val goalNode = Node(to.id.value, to.id, to.world, to.point)
 
-        while (queue.isNotEmpty()) {
-            val (node, nodeDistance) = queue.poll()
-            if (!settled.add(node)) continue // 既に確定済み（PriorityQueue の遅延削除）。
-            if (node == to) break
-            for (edge in adjacency[node].orEmpty()) {
-                if (edge.to in settled) continue
-                val candidate = nodeDistance + edge.timeRequired
-                if (candidate < (distance[edge.to] ?: Long.MAX_VALUE)) {
-                    distance[edge.to] = candidate
-                    incomingEdge[edge.to] = edge
-                    queue.add(edge.to to candidate)
+        val stationNodes = stations.map { Node(it.id.value, it.id, it.world, it.point) }
+        val nodeByKey = HashMap<String, Node>()
+        stationNodes.forEach { nodeByKey[it.key] = it }
+        nodeByKey[fromNode.key] = fromNode // 起点が現在地でも駅でも登録（駅なら上書きで同一）。
+
+        val railAdjacency: Map<String, List<RailEdge>> = buildRailAdjacency(railways)
+        val maxSpeed = maxSpeed(stations, railways, walkSpeed)
+
+        val gScore = HashMap<String, Double>().apply { put(fromNode.key, 0.0) }
+        val incoming = HashMap<String, Incoming>()
+        val settled = HashSet<String>()
+        val open = PriorityQueue<Pair<String, Double>>(compareBy { it.second })
+        open.add(fromNode.key to heuristic(fromNode, goalNode, maxSpeed))
+
+        while (open.isNotEmpty()) {
+            val (key, _) = open.poll()
+            if (!settled.add(key)) continue // 遅延削除。
+            if (key == goalNode.key) break
+            val current = nodeByKey.getValue(key)
+            val baseG = gScore.getValue(key)
+
+            for ((neighbor, incomingEdge) in neighbors(current, stationNodes, railAdjacency, walkSpeed)) {
+                if (neighbor.key in settled) continue
+                val tentative = baseG + incomingEdge.timeSeconds
+                if (tentative < (gScore[neighbor.key] ?: Double.MAX_VALUE)) {
+                    gScore[neighbor.key] = tentative
+                    incoming[neighbor.key] = incomingEdge
+                    open.add(neighbor.key to tentative + heuristic(neighbor, goalNode, maxSpeed))
                 }
             }
         }
 
-        val total = distance[to] ?: return RouteError.NoPath.left()
+        if (goalNode.key !in gScore) return RouteError.NoPath.left()
 
-        // to から from へ辿って経路を復元する。
+        // 終点から起点へ辿って経路を復元する。
         val legs = ArrayDeque<RouteLeg>()
-        var cursor = to
-        while (cursor != from) {
-            val edge = incomingEdge[cursor] ?: return RouteError.NoPath.left()
-            legs.addFirst(RouteLeg(edge.railwayId, edge.from, edge.to, edge.timeRequired, edge.group))
-            cursor = edge.from
+        var cursor = goalNode.key
+        while (cursor != fromNode.key) {
+            val edge = incoming[cursor] ?: return RouteError.NoPath.left()
+            legs.addFirst(
+                RouteLeg(edge.mode, edge.railwayId, edge.fromStation, edge.toStation, edge.timeSeconds, edge.group)
+            )
+            cursor = edge.fromKey
         }
-        return Route(legs.toList(), total).right()
+        return Route(legs.toList(), legs.sumOf { it.timeSeconds }).right()
+    }
+
+    /** レール辺を「出発駅キー -> 辺」の隣接リストにする（無向なので双方向に張る）。 */
+    private fun buildRailAdjacency(railways: List<RailEdge>): Map<String, List<RailEdge>> =
+        railways.flatMap { edge ->
+            listOf(
+                edge,
+                RailEdge(edge.railwayId, edge.to, edge.from, edge.timeRequired, edge.group),
+            )
+        }.groupBy { it.from.value }
+
+    /** [current] から出る辺（レール + 同一ワールドの徒歩）を、A* の重み（秒）は非負の実数で列挙する。 */
+    private fun neighbors(
+        current: Node,
+        stationNodes: List<Node>,
+        railAdjacency: Map<String, List<RailEdge>>,
+        walkSpeed: Double,
+    ): List<Pair<Node, Incoming>> {
+        val result = ArrayList<Pair<Node, Incoming>>()
+        val stationByKey = stationNodes.associateBy { it.key }
+
+        // レール辺（起点が駅のときのみ）。
+        current.stationId?.let { fromId ->
+            for (edge in railAdjacency[current.key].orEmpty()) {
+                val neighbor = stationByKey[edge.to.value] ?: continue
+                result += neighbor to Incoming(
+                    fromKey = current.key,
+                    mode = TravelMode.RAIL,
+                    railwayId = edge.railwayId,
+                    fromStation = fromId,
+                    toStation = edge.to,
+                    timeSeconds = edge.timeRequired,
+                    group = edge.group,
+                )
+            }
+        }
+
+        // 徒歩辺（同一ワールドの他の駅すべて）。
+        for (neighbor in stationNodes) {
+            if (neighbor.key == current.key) continue
+            if (neighbor.world != current.world) continue
+            val walkSeconds = (current.point.distanceTo2D(neighbor.point) / walkSpeed).roundToLong()
+            result += neighbor to Incoming(
+                fromKey = current.key,
+                mode = TravelMode.WALK,
+                railwayId = null,
+                fromStation = current.stationId,
+                toStation = neighbor.stationId!!, // stationNodes は必ず駅。
+                timeSeconds = walkSeconds,
+                group = null,
+            )
+        }
+        return result
+    }
+
+    /**
+     * ヒューリスティック: 終点までの直線水平距離 ÷ [maxSpeed]。
+     * ワールドが異なる場合は距離を見積もれないため 0（常に許容的）。
+     */
+    private fun heuristic(node: Node, goal: Node, maxSpeed: Double): Double =
+        if (node.world != goal.world) 0.0 else node.point.distanceTo2D(goal.point) / maxSpeed
+
+    /** グラフ内の最大「直線変位速度」（徒歩とレールの実効速度の最大）。ヒューリスティックの許容性のため。 */
+    private fun maxSpeed(stations: List<StationNode>, railways: List<RailEdge>, walkSpeed: Double): Double {
+        val pointById = stations.associate { it.id.value to it.point }
+        var max = walkSpeed
+        for (edge in railways) {
+            if (edge.timeRequired <= 0) continue
+            val a = pointById[edge.from.value] ?: continue
+            val b = pointById[edge.to.value] ?: continue
+            val distance = a.distanceTo2D(b)
+            if (distance <= 0.0) continue
+            val speed = distance / edge.timeRequired
+            if (speed > max) max = speed
+        }
+        return max
     }
 }

--- a/src/main/kotlin/dev/nikomaru/advancerailway/route/RouteFinder.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/route/RouteFinder.kt
@@ -1,0 +1,134 @@
+/*
+ * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ *
+ * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication along with this software.
+ * If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+package dev.nikomaru.advancerailway.route
+
+import arrow.core.Either
+import arrow.core.left
+import arrow.core.right
+import dev.nikomaru.advancerailway.file.data.RailwayData
+import dev.nikomaru.advancerailway.file.value.GroupId
+import dev.nikomaru.advancerailway.file.value.RailwayId
+import dev.nikomaru.advancerailway.file.value.StationId
+import java.util.PriorityQueue
+
+/**
+ * ネットワークグラフ上の 1 本の有向辺。
+ * 駅 [from] から駅 [to] へ、路線 [railwayId] を [timeRequired] 秒で結ぶ。
+ */
+data class RouteEdge(
+    val railwayId: RailwayId,
+    val from: StationId,
+    val to: StationId,
+    val timeRequired: Long,
+    val group: GroupId?,
+)
+
+/** 求めた経路の 1 区間（1 本の路線に乗る単位）。 */
+data class RouteLeg(
+    val railwayId: RailwayId,
+    val from: StationId,
+    val to: StationId,
+    val timeRequired: Long,
+    val group: GroupId?,
+)
+
+/** 出発駅から到着駅までの経路探索結果。 */
+data class Route(
+    val legs: List<RouteLeg>,
+    /**
+     * 合計所要時間（秒）。
+     * 区間ごとに分へ丸めてから合算すると誤差が積み上がるため、生の秒で合算した値を保持する。
+     */
+    val totalSeconds: Long,
+) {
+    /** 出発駅から到着駅まで、通過順に並んだ駅列。 */
+    val stations: List<StationId>
+        get() = if (legs.isEmpty()) emptyList() else listOf(legs.first().from) + legs.map { it.to }
+}
+
+/** 経路を返せなかった理由。 */
+sealed interface RouteError {
+    /** 出発駅と到着駅が同一。 */
+    data object SameStation : RouteError
+
+    /** 出発駅と到着駅の間に経路が存在しない（未接続 / 孤立駅）。 */
+    data object NoPath : RouteError
+}
+
+/**
+ * 路線データを重み付きグラフとみなし、駅間の最短（所要時間最小）経路を求める純粋ロジック。
+ *
+ * Bukkit / Koin に依存せず、[RouteEdge] のリストと [StationId] のみで完結するため、
+ * サーバーを起動しなくても単体テストできる（[dev.nikomaru.advancerailway.mineauth.dto.RailwayDtoMapper]
+ * と同じ「サーバー非依存の純粋ロジックを切り出す」方針）。
+ */
+object RouteFinder {
+
+    /**
+     * すべての [RailwayData] からグラフの辺集合を構築する。
+     *
+     * v1 では路線を**無向辺**として扱い、各路線につき両方向の [RouteEdge] を張る。
+     * [dev.nikomaru.advancerailway.file.type.LineType] による方向別ルーティング
+     * （UP_LINE / DOWN_LINE の区別）は、既存データがすべて UP_DOWN_LINE であり
+     * from/to の意味が確定していないため、将来対応とする。
+     */
+    fun buildEdges(railways: List<RailwayData>): List<RouteEdge> = railways.flatMap { railway ->
+        listOf(
+            RouteEdge(railway.id, railway.fromStation, railway.toStation, railway.timeRequired, railway.group),
+            RouteEdge(railway.id, railway.toStation, railway.fromStation, railway.timeRequired, railway.group),
+        )
+    }
+
+    /**
+     * [from] から [to] までの、所要時間が最小となる経路を Dijkstra 法で求める。
+     *
+     * [timeRequired]（秒、非負）を辺の重みとする。駅の存在確認は行わない
+     * （呼び出し側が事前に検証する想定）。到達不能な場合は [RouteError.NoPath] を返す。
+     *
+     * @return 最短経路、または探索に失敗した理由。
+     */
+    fun findRoute(edges: List<RouteEdge>, from: StationId, to: StationId): Either<RouteError, Route> {
+        if (from == to) return RouteError.SameStation.left()
+
+        val adjacency: Map<StationId, List<RouteEdge>> = edges.groupBy { it.from }
+        val distance = HashMap<StationId, Long>().apply { put(from, 0L) }
+        val incomingEdge = HashMap<StationId, RouteEdge>()
+        val settled = HashSet<StationId>()
+        val queue = PriorityQueue<Pair<StationId, Long>>(compareBy { it.second })
+        queue.add(from to 0L)
+
+        while (queue.isNotEmpty()) {
+            val (node, nodeDistance) = queue.poll()
+            if (!settled.add(node)) continue // 既に確定済み（PriorityQueue の遅延削除）。
+            if (node == to) break
+            for (edge in adjacency[node].orEmpty()) {
+                if (edge.to in settled) continue
+                val candidate = nodeDistance + edge.timeRequired
+                if (candidate < (distance[edge.to] ?: Long.MAX_VALUE)) {
+                    distance[edge.to] = candidate
+                    incomingEdge[edge.to] = edge
+                    queue.add(edge.to to candidate)
+                }
+            }
+        }
+
+        val total = distance[to] ?: return RouteError.NoPath.left()
+
+        // to から from へ辿って経路を復元する。
+        val legs = ArrayDeque<RouteLeg>()
+        var cursor = to
+        while (cursor != from) {
+            val edge = incomingEdge[cursor] ?: return RouteError.NoPath.left()
+            legs.addFirst(RouteLeg(edge.railwayId, edge.from, edge.to, edge.timeRequired, edge.group))
+            cursor = edge.from
+        }
+        return Route(legs.toList(), total).right()
+    }
+}

--- a/src/test/kotlin/dev/nikomaru/advancerailway/mineauth/RailwayApiHandlerTest.kt
+++ b/src/test/kotlin/dev/nikomaru/advancerailway/mineauth/RailwayApiHandlerTest.kt
@@ -124,9 +124,9 @@ class RailwayApiHandlerTest {
     fun listStationsReturnsAll() = runBlocking {
         val response = handler.listStations()
 
-        assertEquals(2, response.stations.size)
+        assertEquals(3, response.stations.size)
         val ids = response.stations.map { it.id }.toSet()
-        assertEquals(setOf("st01", "st02"), ids)
+        assertEquals(setOf("st01", "st02", "st03"), ids)
     }
 
     @Test
@@ -205,12 +205,77 @@ class RailwayApiHandlerTest {
         assertEquals(HttpStatus.NOT_FOUND, error.status)
     }
 
+    @Test
+    @DisplayName("getRoute returns a single-leg route between connected stations")
+    fun getRouteReturnsRoute() = runBlocking {
+        val route = handler.getRoute("st01", "st02")
+
+        assertEquals("st01", route.from)
+        assertEquals("st02", route.to)
+        assertEquals(120L, route.totalTime)
+        assertEquals(listOf("st01", "st02"), route.stations)
+        assertEquals(1, route.legs.size)
+        assertEquals("rw01", route.legs.first().railway)
+        assertEquals("g1", route.legs.first().group)
+    }
+
+    @Test
+    @DisplayName("getRoute is undirected: the reverse direction also routes")
+    fun getRouteReverse() = runBlocking {
+        val route = handler.getRoute("st02", "st01")
+
+        assertEquals(listOf("st02", "st01"), route.stations)
+        assertEquals(120L, route.totalTime)
+    }
+
+    @Test
+    @DisplayName("getRoute throws BAD_REQUEST when from equals to")
+    fun getRouteSameStation() {
+        val error = assertThrows<HttpError> {
+            runBlocking { handler.getRoute("st01", "st01") }
+        }
+        assertEquals(HttpStatus.BAD_REQUEST, error.status)
+        assertEquals("same_station", error.code)
+    }
+
+    @Test
+    @DisplayName("getRoute throws NOT_FOUND (no_route) for a disconnected station")
+    fun getRouteNoPath() {
+        val error = assertThrows<HttpError> {
+            runBlocking { handler.getRoute("st01", "st03") }
+        }
+        assertEquals(HttpStatus.NOT_FOUND, error.status)
+        assertEquals("no_route", error.code)
+    }
+
+    @Test
+    @DisplayName("getRoute throws NOT_FOUND (station_not_found) for an unknown station")
+    fun getRouteUnknownStation() {
+        val error = assertThrows<HttpError> {
+            runBlocking { handler.getRoute("st01", "does-not-exist") }
+        }
+        assertEquals(HttpStatus.NOT_FOUND, error.status)
+        assertEquals("station_not_found", error.code)
+    }
+
+    @Test
+    @DisplayName("getRoute rejects a path-traversal station id before touching disk")
+    fun getRouteRejectsInvalidId() {
+        val error = assertThrows<HttpError> {
+            runBlocking { handler.getRoute("../config", "st02") }
+        }
+        assertEquals(HttpStatus.NOT_FOUND, error.status)
+        assertEquals("station_not_found", error.code)
+    }
+
     /**
      * テスト用の駅・路線・グループを実際のシリアライズ形式で dataFolder へ書き出す。
      */
     private fun writeFixtures() {
         writeStation("st01", "Central", Point3D(1.0, 64.0, -3.0), Color(255, 127, 0))
         writeStation("st02", "North", Point3D(5.0, 64.0, 10.0), Color(0, 0, 255))
+        // st03 は路線に接続されない孤立駅（経路探索の NoPath ケース用）。
+        writeStation("st03", "Isolated", Point3D(9.0, 64.0, 20.0), Color(128, 128, 128))
 
         val railway = RailwayData(
             id = RailwayId("rw01"),

--- a/src/test/kotlin/dev/nikomaru/advancerailway/mineauth/RailwayApiHandlerTest.kt
+++ b/src/test/kotlin/dev/nikomaru/advancerailway/mineauth/RailwayApiHandlerTest.kt
@@ -26,6 +26,8 @@ import kotlinx.coroutines.runBlocking
 import org.bukkit.World
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -68,6 +70,8 @@ class RailwayApiHandlerTest {
 
         server = MockBukkit.mock()
         world = server.addSimpleWorld("world")
+        // 別ワールド（経路探索のクロスワールド NoPath ケース用）。
+        server.addSimpleWorld("world_nether")
 
         dataFolder = Files.createTempDirectory("advancerailway-test").toFile()
 
@@ -124,9 +128,9 @@ class RailwayApiHandlerTest {
     fun listStationsReturnsAll() = runBlocking {
         val response = handler.listStations()
 
-        assertEquals(3, response.stations.size)
+        assertEquals(4, response.stations.size)
         val ids = response.stations.map { it.id }.toSet()
-        assertEquals(setOf("st01", "st02", "st03"), ids)
+        assertEquals(setOf("st01", "st02", "st03", "nt01"), ids)
     }
 
     @Test
@@ -138,7 +142,7 @@ class RailwayApiHandlerTest {
         assertEquals("UP_LINE", railway.lineType)
         assertEquals("st01", railway.fromStation)
         assertEquals("st02", railway.toStation)
-        assertEquals(120L, railway.timeRequired)
+        assertEquals(2L, railway.timeRequired)
     }
 
     @Test
@@ -206,26 +210,43 @@ class RailwayApiHandlerTest {
     }
 
     @Test
-    @DisplayName("getRoute returns a single-leg route between connected stations")
+    @DisplayName("getRoute picks the fast rail leg between connected stations")
     fun getRouteReturnsRoute() = runBlocking {
         val route = handler.getRoute("st01", "st02")
 
         assertEquals("st01", route.from)
         assertEquals("st02", route.to)
-        assertEquals(120L, route.totalTime)
+        assertEquals(2L, route.totalTime)
         assertEquals(listOf("st01", "st02"), route.stations)
         assertEquals(1, route.legs.size)
+        assertEquals("RAIL", route.legs.first().mode)
         assertEquals("rw01", route.legs.first().railway)
         assertEquals("g1", route.legs.first().group)
     }
 
     @Test
-    @DisplayName("getRoute is undirected: the reverse direction also routes")
+    @DisplayName("getRoute is undirected: the reverse direction also routes by rail")
     fun getRouteReverse() = runBlocking {
         val route = handler.getRoute("st02", "st01")
 
         assertEquals(listOf("st02", "st01"), route.stations)
-        assertEquals(120L, route.totalTime)
+        assertEquals("RAIL", route.legs.first().mode)
+        assertEquals(2L, route.totalTime)
+    }
+
+    @Test
+    @DisplayName("getRoute reaches a rail-disconnected station via rail then a final walk")
+    fun getRouteWalkingFallback() = runBlocking {
+        // st03 has no railway; the cheapest path is rail st01->st02 then a short walk to st03.
+        val route = handler.getRoute("st01", "st03")
+
+        assertEquals(listOf("st01", "st02", "st03"), route.stations)
+        assertEquals("RAIL", route.legs.first().mode)
+        val last = route.legs.last()
+        assertEquals("WALK", last.mode)
+        assertNull(last.railway)
+        assertEquals("st03", last.to)
+        assertEquals(4L, route.totalTime)
     }
 
     @Test
@@ -239,10 +260,10 @@ class RailwayApiHandlerTest {
     }
 
     @Test
-    @DisplayName("getRoute throws NOT_FOUND (no_route) for a disconnected station")
+    @DisplayName("getRoute throws NOT_FOUND (no_route) for a station in another world with no bridging rail")
     fun getRouteNoPath() {
         val error = assertThrows<HttpError> {
-            runBlocking { handler.getRoute("st01", "st03") }
+            runBlocking { handler.getRoute("st01", "nt01") }
         }
         assertEquals(HttpStatus.NOT_FOUND, error.status)
         assertEquals("no_route", error.code)
@@ -274,9 +295,12 @@ class RailwayApiHandlerTest {
     private fun writeFixtures() {
         writeStation("st01", "Central", Point3D(1.0, 64.0, -3.0), Color(255, 127, 0))
         writeStation("st02", "North", Point3D(5.0, 64.0, 10.0), Color(0, 0, 255))
-        // st03 は路線に接続されない孤立駅（経路探索の NoPath ケース用）。
+        // st03 は路線に接続されない孤立駅（同一ワールドなので徒歩フォールバックで到達できる）。
         writeStation("st03", "Isolated", Point3D(9.0, 64.0, 20.0), Color(128, 128, 128))
+        // nt01 は別ワールドの駅（レール未接続 → クロスワールドで NoPath）。
+        writeStation("nt01", "Nether", Point3D(0.0, 64.0, 0.0), Color(200, 0, 0), server.getWorld("world_nether")!!)
 
+        // rw01 の所要時間は徒歩（約 3 秒）より速い 2 秒とし、st01<->st02 ではレールが選ばれるようにする。
         val railway = RailwayData(
             id = RailwayId("rw01"),
             group = GroupId("g1"),
@@ -285,7 +309,7 @@ class RailwayApiHandlerTest {
             line = Line3D(Point3D(1.0, 64.0, -3.0), Point3D(5.0, 64.0, 10.0)),
             fromStation = StationId("st01"),
             toStation = StationId("st02"),
-            timeRequired = 120L,
+            timeRequired = 2L,
             startPoint = Point3D(1.0, 64.0, -3.0),
             endPoint = Point3D(5.0, 64.0, 10.0),
             directionPoint = Point3D(2.0, 64.0, -3.0),
@@ -296,12 +320,12 @@ class RailwayApiHandlerTest {
         write("groups", "g1", json.encodeToString(group))
     }
 
-    private fun writeStation(id: String, name: String, point: Point3D, color: Color) {
+    private fun writeStation(id: String, name: String, point: Point3D, color: Color, inWorld: World = world) {
         val station = StationData(
             stationId = StationId(id),
             name = name,
             numbering = null,
-            world = world,
+            world = inWorld,
             point = point,
             overrideSize = null,
             color = color,

--- a/src/test/kotlin/dev/nikomaru/advancerailway/mineauth/RailwayApiHandlerTest.kt
+++ b/src/test/kotlin/dev/nikomaru/advancerailway/mineauth/RailwayApiHandlerTest.kt
@@ -245,6 +245,7 @@ class RailwayApiHandlerTest {
         val last = route.legs.last()
         assertEquals("WALK", last.mode)
         assertNull(last.railway)
+        assertNull(last.group) // the rail group must not leak onto the walk leg
         assertEquals("st03", last.to)
         assertEquals(4L, route.totalTime)
     }

--- a/src/test/kotlin/dev/nikomaru/advancerailway/route/RouteFinderTest.kt
+++ b/src/test/kotlin/dev/nikomaru/advancerailway/route/RouteFinderTest.kt
@@ -9,90 +9,121 @@
 
 package dev.nikomaru.advancerailway.route
 
+import arrow.core.Either
+import dev.nikomaru.advancerailway.Point3D
 import dev.nikomaru.advancerailway.file.value.GroupId
 import dev.nikomaru.advancerailway.file.value.RailwayId
 import dev.nikomaru.advancerailway.file.value.StationId
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 
 /**
- * [RouteFinder] の純粋なグラフ探索ロジックの単体テスト。
- * Bukkit / Koin に依存しないため、サーバーを起動せずに [RouteEdge] を直接組み立てて検証する。
+ * [RouteFinder] の純粋な幾何グラフ探索（レール + 徒歩、A*）の単体テスト。
+ * Bukkit / Koin に依存しないため、[StationNode] / [RailEdge] を直接組み立てて検証する。
  */
 class RouteFinderTest {
 
-    private fun st(id: String) = StationId(id)
-    private fun rw(id: String) = RailwayId(id)
+    private fun station(id: String, x: Double, z: Double, world: String = "world") =
+        StationNode(StationId(id), world, Point3D(x, 64.0, z))
 
-    /** 双方向の辺（無向路線）を張るヘルパ。既定の buildEdges と同じ扱い。 */
-    private fun undirected(railway: String, a: String, b: String, time: Long, group: String? = null): List<RouteEdge> {
-        val g = group?.let { GroupId(it) }
-        return listOf(
-            RouteEdge(rw(railway), st(a), st(b), time, g),
-            RouteEdge(rw(railway), st(b), st(a), time, g),
-        )
+    private fun rail(id: String, from: StationNode, to: StationNode, time: Long, group: String? = null) =
+        RailEdge(RailwayId(id), from.id, to.id, time, group?.let { GroupId(it) })
+
+    private fun rightOrFail(result: Either<RouteError, Route>): Route {
+        assertInstanceOf(Either.Right::class.java, result, "expected a route but got $result")
+        return (result as Either.Right).value
     }
 
-    private fun rightOrFail(result: arrow.core.Either<RouteError, Route>): Route {
-        assertInstanceOf(arrow.core.Either.Right::class.java, result, "expected a route but got $result")
-        return (result as arrow.core.Either.Right).value
+    private fun leftOf(result: Either<RouteError, Route>): RouteError {
+        assertInstanceOf(Either.Left::class.java, result, "expected an error but got $result")
+        return (result as Either.Left).value
     }
 
     @Test
-    @DisplayName("finds a single-leg route across one railway")
-    fun singleLeg() {
-        val edges = undirected("rw-ab", "a", "b", 120)
-        val route = rightOrFail(RouteFinder.findRoute(edges, st("a"), st("b")))
+    @DisplayName("prefers a fast rail over the slow walking edge between far stations")
+    fun prefersRail() {
+        val a = station("a", 0.0, 0.0)
+        val b = station("b", 1000.0, 0.0) // walking ~232s
+        val route = rightOrFail(RouteFinder.findRoute(listOf(a, b), listOf(rail("rw", a, b, 10)), Waypoint.Station(a), b))
 
         assertEquals(1, route.legs.size)
-        assertEquals(120L, route.totalSeconds)
-        assertEquals(listOf("a", "b"), route.stations.map { it.value })
-        assertEquals("rw-ab", route.legs.first().railwayId.value)
+        assertEquals(TravelMode.RAIL, route.legs.first().mode)
+        assertEquals("rw", route.legs.first().railwayId?.value)
+        assertEquals(10L, route.totalSeconds)
     }
 
     @Test
-    @DisplayName("chains multiple railways into a multi-leg route and sums seconds")
-    fun multiLeg() {
-        val edges = undirected("rw-ab", "a", "b", 60) + undirected("rw-bc", "b", "c", 90)
-        val route = rightOrFail(RouteFinder.findRoute(edges, st("a"), st("c")))
+    @DisplayName("falls back to a walking leg when no rail connects the stations")
+    fun walkingFallback() {
+        val a = station("a", 0.0, 0.0)
+        val b = station("b", 10.0, 0.0) // 10 / 4.317 = 2.3 -> 2s
+        val route = rightOrFail(RouteFinder.findRoute(listOf(a, b), emptyList(), Waypoint.Station(a), b))
+
+        assertEquals(1, route.legs.size)
+        assertEquals(TravelMode.WALK, route.legs.first().mode)
+        assertNull(route.legs.first().railwayId)
+        assertEquals(2L, route.totalSeconds)
+    }
+
+    @Test
+    @DisplayName("takes a walking shortcut when it beats a slow rail")
+    fun walkingBeatsSlowRail() {
+        val a = station("a", 0.0, 0.0)
+        val b = station("b", 10.0, 0.0)
+        val route = rightOrFail(
+            RouteFinder.findRoute(listOf(a, b), listOf(rail("slow", a, b, 100)), Waypoint.Station(a), b)
+        )
+
+        assertEquals(TravelMode.WALK, route.legs.first().mode)
+        assertEquals(2L, route.totalSeconds)
+    }
+
+    @Test
+    @DisplayName("chains rail hops and prefers them over a long direct walk")
+    fun multiHopRail() {
+        val a = station("a", 0.0, 0.0)
+        val b = station("b", 1000.0, 0.0)
+        val c = station("c", 2000.0, 0.0)
+        val route = rightOrFail(
+            RouteFinder.findRoute(
+                listOf(a, b, c), listOf(rail("ab", a, b, 10), rail("bc", b, c, 10)), Waypoint.Station(a), c
+            )
+        )
 
         assertEquals(2, route.legs.size)
-        assertEquals(150L, route.totalSeconds)
+        assertTrue(route.legs.all { it.mode == TravelMode.RAIL })
         assertEquals(listOf("a", "b", "c"), route.stations.map { it.value })
-    }
-
-    @Test
-    @DisplayName("prefers the shortest total time over fewer hops")
-    fun prefersShortestTime() {
-        // Direct a->c costs 1000; the two-hop a->b->c costs 20. Dijkstra must pick the cheaper.
-        val edges = undirected("rw-ac", "a", "c", 1000) +
-            undirected("rw-ab", "a", "b", 10) +
-            undirected("rw-bc", "b", "c", 10)
-        val route = rightOrFail(RouteFinder.findRoute(edges, st("a"), st("c")))
-
         assertEquals(20L, route.totalSeconds)
-        assertEquals(listOf("a", "b", "c"), route.stations.map { it.value })
     }
 
     @Test
-    @DisplayName("treats railways as undirected: the reverse direction is routable")
-    fun reverseIsRoutable() {
-        val edges = undirected("rw-ab", "a", "b", 42)
-        val route = rightOrFail(RouteFinder.findRoute(edges, st("b"), st("a")))
+    @DisplayName("combines a walk from the current location with a rail hop")
+    fun originThenRail() {
+        val a = station("a", 1.0, 0.0)
+        val b = station("b", 1000.0, 0.0)
+        val origin = Waypoint.Origin("world", Point3D(0.0, 64.0, 0.0)) // ~0.2s walk to a
+        val route = rightOrFail(RouteFinder.findRoute(listOf(a, b), listOf(rail("ab", a, b, 10)), origin, b))
 
-        assertEquals(1, route.legs.size)
-        assertEquals(42L, route.totalSeconds)
-        assertEquals(listOf("b", "a"), route.stations.map { it.value })
+        assertEquals(2, route.legs.size)
+        assertEquals(TravelMode.WALK, route.legs.first().mode)
+        assertNull(route.legs.first().from) // starts from the current location
+        assertEquals(TravelMode.RAIL, route.legs.last().mode)
+        // current location is not a station, so the station list starts at 'a'.
+        assertEquals(listOf("a", "b"), route.stations.map { it.value })
     }
 
     @Test
-    @DisplayName("carries the group through to each leg")
+    @DisplayName("carries the group through rail legs")
     fun carriesGroup() {
-        val edges = undirected("rw-ab", "a", "b", 30, group = "main-line")
-        val route = rightOrFail(RouteFinder.findRoute(edges, st("a"), st("b")))
+        val a = station("a", 0.0, 0.0)
+        val b = station("b", 1000.0, 0.0)
+        val route = rightOrFail(
+            RouteFinder.findRoute(listOf(a, b), listOf(rail("rw", a, b, 10, group = "main-line")), Waypoint.Station(a), b)
+        )
 
         assertEquals("main-line", route.legs.first().group?.value)
     }
@@ -100,30 +131,29 @@ class RouteFinderTest {
     @Test
     @DisplayName("returns SameStation when from equals to")
     fun sameStation() {
-        val edges = undirected("rw-ab", "a", "b", 10)
-        val result = RouteFinder.findRoute(edges, st("a"), st("a"))
-
-        assertTrue(result.isLeft())
-        assertEquals(RouteError.SameStation, (result as arrow.core.Either.Left).value)
+        val a = station("a", 0.0, 0.0)
+        assertEquals(RouteError.SameStation, leftOf(RouteFinder.findRoute(listOf(a), emptyList(), Waypoint.Station(a), a)))
     }
 
     @Test
-    @DisplayName("returns NoPath when the destination is in a disconnected component")
-    fun noPathDisconnected() {
-        val edges = undirected("rw-ab", "a", "b", 10) + undirected("rw-cd", "c", "d", 10)
-        val result = RouteFinder.findRoute(edges, st("a"), st("d"))
-
-        assertTrue(result.isLeft())
-        assertEquals(RouteError.NoPath, (result as arrow.core.Either.Left).value)
+    @DisplayName("returns NoPath across worlds with no bridging rail")
+    fun noPathAcrossWorlds() {
+        val a = station("a", 0.0, 0.0, world = "world")
+        val b = station("b", 0.0, 0.0, world = "world_nether")
+        assertEquals(RouteError.NoPath, leftOf(RouteFinder.findRoute(listOf(a, b), emptyList(), Waypoint.Station(a), b)))
     }
 
     @Test
-    @DisplayName("returns NoPath when the origin has no edges at all")
-    fun noPathIsolatedOrigin() {
-        val edges = undirected("rw-bc", "b", "c", 10)
-        val result = RouteFinder.findRoute(edges, st("a"), st("c"))
+    @DisplayName("rail bridges two worlds even without a walking edge")
+    fun railBridgesWorlds() {
+        val a = station("a", 0.0, 0.0, world = "world")
+        val b = station("b", 0.0, 0.0, world = "world_nether")
+        val route = rightOrFail(
+            RouteFinder.findRoute(listOf(a, b), listOf(rail("portal", a, b, 50)), Waypoint.Station(a), b)
+        )
 
-        assertTrue(result.isLeft())
-        assertEquals(RouteError.NoPath, (result as arrow.core.Either.Left).value)
+        assertEquals(1, route.legs.size)
+        assertEquals(TravelMode.RAIL, route.legs.first().mode)
+        assertEquals(50L, route.totalSeconds)
     }
 }

--- a/src/test/kotlin/dev/nikomaru/advancerailway/route/RouteFinderTest.kt
+++ b/src/test/kotlin/dev/nikomaru/advancerailway/route/RouteFinderTest.kt
@@ -66,6 +66,7 @@ class RouteFinderTest {
         assertEquals(1, route.legs.size)
         assertEquals(TravelMode.WALK, route.legs.first().mode)
         assertNull(route.legs.first().railwayId)
+        assertNull(route.legs.first().group)
         assertEquals(2L, route.totalSeconds)
     }
 
@@ -101,19 +102,81 @@ class RouteFinderTest {
     }
 
     @Test
-    @DisplayName("combines a walk from the current location with a rail hop")
-    fun originThenRail() {
-        val a = station("a", 1.0, 0.0)
+    @DisplayName("rides rail then walks the last stretch to a rail-disconnected station")
+    fun railThenWalkCombo() {
+        val a = station("a", 0.0, 0.0)
         val b = station("b", 1000.0, 0.0)
-        val origin = Waypoint.Origin("world", Point3D(0.0, 64.0, 0.0)) // ~0.2s walk to a
+        val c = station("c", 1010.0, 0.0) // 10 blocks from b, no rail -> 2s walk
+        val route = rightOrFail(
+            RouteFinder.findRoute(
+                listOf(a, b, c), listOf(rail("ab", a, b, 5, group = "main")), Waypoint.Station(a), c
+            )
+        )
+
+        assertEquals(2, route.legs.size)
+        assertEquals(TravelMode.RAIL, route.legs[0].mode)
+        assertEquals("main", route.legs[0].group?.value)
+        assertEquals(TravelMode.WALK, route.legs[1].mode)
+        assertNull(route.legs[1].group) // the rail group must not leak onto the walk leg
+        assertEquals("c", route.legs[1].to.value)
+        assertEquals(7L, route.totalSeconds) // 5s rail + 2s walk
+    }
+
+    @Test
+    @DisplayName("combines a walk from the current location with a rail hop and pins the walk time")
+    fun originThenRail() {
+        val a = station("a", 10.0, 0.0) // origin -> a is 10 blocks = 2s
+        val b = station("b", 1000.0, 0.0)
+        val origin = Waypoint.Origin("world", Point3D(0.0, 64.0, 0.0))
         val route = rightOrFail(RouteFinder.findRoute(listOf(a, b), listOf(rail("ab", a, b, 10)), origin, b))
 
         assertEquals(2, route.legs.size)
         assertEquals(TravelMode.WALK, route.legs.first().mode)
         assertNull(route.legs.first().from) // starts from the current location
+        assertEquals(2L, route.legs.first().timeSeconds) // 10 / 4.317 = 2.3 -> 2s
         assertEquals(TravelMode.RAIL, route.legs.last().mode)
+        assertEquals(12L, route.totalSeconds) // 2s walk + 10s rail
         // current location is not a station, so the station list starts at 'a'.
         assertEquals(listOf("a", "b"), route.stations.map { it.value })
+    }
+
+    @Test
+    @DisplayName("uses unrounded costs so a rail beats an accumulated per-hop walk rounding")
+    fun usesUnroundedCostsForSearch() {
+        // Three 6-block walk hops: each rounds 1.39s -> 1s, so a naive per-hop-rounded search would
+        // total 3s and wrongly beat the 4s rail. Unrounded, the walk path is ~4.17s, so rail wins.
+        val a = station("a", 0.0, 0.0)
+        val b = station("b", 6.0, 0.0)
+        val c = station("c", 12.0, 0.0)
+        val d = station("d", 18.0, 0.0)
+        val route = rightOrFail(
+            RouteFinder.findRoute(listOf(a, b, c, d), listOf(rail("ad", a, d, 4)), Waypoint.Station(a), d)
+        )
+
+        assertEquals(1, route.legs.size)
+        assertEquals(TravelMode.RAIL, route.legs.first().mode)
+        assertEquals(4L, route.totalSeconds)
+    }
+
+    @Test
+    @DisplayName("totalSeconds equals the sum of the per-leg rounded seconds")
+    fun totalIsSumOfLegs() {
+        val a = station("a", 0.0, 0.0)
+        val b = station("b", 10.0, 0.0)
+        val c = station("c", 25.0, 0.0)
+        val route = rightOrFail(RouteFinder.findRoute(listOf(a, b, c), emptyList(), Waypoint.Station(a), c))
+
+        assertEquals(route.legs.sumOf { it.timeSeconds }, route.totalSeconds)
+    }
+
+    @Test
+    @DisplayName("uses the horizontal (2D) distance, ignoring the y difference")
+    fun ignoresVerticalDistance() {
+        val a = StationNode(StationId("a"), "world", Point3D(0.0, 0.0, 0.0))
+        val b = StationNode(StationId("b"), "world", Point3D(10.0, 500.0, 0.0)) // huge y gap
+        val route = rightOrFail(RouteFinder.findRoute(listOf(a, b), emptyList(), Waypoint.Station(a), b))
+
+        assertEquals(2L, route.totalSeconds) // 10 / 4.317 = 2s, y ignored
     }
 
     @Test
@@ -129,10 +192,34 @@ class RouteFinderTest {
     }
 
     @Test
+    @DisplayName("respects a custom walk speed")
+    fun customWalkSpeed() {
+        val a = station("a", 0.0, 0.0)
+        val b = station("b", 20.0, 0.0)
+        // At 10 b/s, 20 blocks = 2s (vs ~4.6s at the default speed).
+        val route = rightOrFail(RouteFinder.findRoute(listOf(a, b), emptyList(), Waypoint.Station(a), b, walkSpeed = 10.0))
+
+        assertEquals(2L, route.totalSeconds)
+    }
+
+    @Test
     @DisplayName("returns SameStation when from equals to")
     fun sameStation() {
         val a = station("a", 0.0, 0.0)
         assertEquals(RouteError.SameStation, leftOf(RouteFinder.findRoute(listOf(a), emptyList(), Waypoint.Station(a), a)))
+    }
+
+    @Test
+    @DisplayName("does not report SameStation when an Origin sits on the destination")
+    fun originOnDestinationIsNotSameStation() {
+        // An Origin has no station id, so from==to can't trigger SameStation; it should route (0s walk).
+        val a = station("a", 0.0, 0.0)
+        val origin = Waypoint.Origin("world", Point3D(0.0, 64.0, 0.0))
+        val route = rightOrFail(RouteFinder.findRoute(listOf(a), emptyList(), origin, a))
+
+        assertEquals(1, route.legs.size)
+        assertEquals(TravelMode.WALK, route.legs.first().mode)
+        assertEquals("a", route.legs.first().to.value)
     }
 
     @Test
@@ -155,5 +242,34 @@ class RouteFinderTest {
         assertEquals(1, route.legs.size)
         assertEquals(TravelMode.RAIL, route.legs.first().mode)
         assertEquals(50L, route.totalSeconds)
+    }
+
+    @Test
+    @DisplayName("a railway referencing an unknown station does not crash the search")
+    fun railwayToUnknownStationIsIgnored() {
+        val a = station("a", 0.0, 0.0)
+        val b = station("b", 10.0, 0.0)
+        // rail 'ghost' points a -> zzz which is not in the station list; it must be skipped, walking still works.
+        val ghost = RailEdge(RailwayId("ghost"), a.id, StationId("zzz"), 1, null)
+        val route = rightOrFail(RouteFinder.findRoute(listOf(a, b), listOf(ghost), Waypoint.Station(a), b))
+
+        assertEquals(TravelMode.WALK, route.legs.first().mode)
+        assertEquals(2L, route.totalSeconds)
+    }
+
+    @Test
+    @DisplayName("ignores a zero-length degenerate rail in the heuristic without crashing")
+    fun zeroLengthRailDoesNotBreakHeuristic() {
+        // Two stations at the same point connected by a 0s rail; maxSpeed must not divide by zero.
+        val a = station("a", 0.0, 0.0)
+        val b = station("b", 0.0, 0.0)
+        val c = station("c", 100.0, 0.0)
+        val route = rightOrFail(
+            RouteFinder.findRoute(
+                listOf(a, b, c), listOf(rail("ab0", a, b, 0), rail("bc", b, c, 5)), Waypoint.Station(a), c
+            )
+        )
+
+        assertEquals(5L, route.totalSeconds) // 0s a->b + 5s b->c
     }
 }

--- a/src/test/kotlin/dev/nikomaru/advancerailway/route/RouteFinderTest.kt
+++ b/src/test/kotlin/dev/nikomaru/advancerailway/route/RouteFinderTest.kt
@@ -1,0 +1,129 @@
+/*
+ * Written in 2024 by Nikomaru <nikomaru@nikomaru.dev>
+ *
+ * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication along with this software.
+ * If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+package dev.nikomaru.advancerailway.route
+
+import dev.nikomaru.advancerailway.file.value.GroupId
+import dev.nikomaru.advancerailway.file.value.RailwayId
+import dev.nikomaru.advancerailway.file.value.StationId
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+/**
+ * [RouteFinder] の純粋なグラフ探索ロジックの単体テスト。
+ * Bukkit / Koin に依存しないため、サーバーを起動せずに [RouteEdge] を直接組み立てて検証する。
+ */
+class RouteFinderTest {
+
+    private fun st(id: String) = StationId(id)
+    private fun rw(id: String) = RailwayId(id)
+
+    /** 双方向の辺（無向路線）を張るヘルパ。既定の buildEdges と同じ扱い。 */
+    private fun undirected(railway: String, a: String, b: String, time: Long, group: String? = null): List<RouteEdge> {
+        val g = group?.let { GroupId(it) }
+        return listOf(
+            RouteEdge(rw(railway), st(a), st(b), time, g),
+            RouteEdge(rw(railway), st(b), st(a), time, g),
+        )
+    }
+
+    private fun rightOrFail(result: arrow.core.Either<RouteError, Route>): Route {
+        assertInstanceOf(arrow.core.Either.Right::class.java, result, "expected a route but got $result")
+        return (result as arrow.core.Either.Right).value
+    }
+
+    @Test
+    @DisplayName("finds a single-leg route across one railway")
+    fun singleLeg() {
+        val edges = undirected("rw-ab", "a", "b", 120)
+        val route = rightOrFail(RouteFinder.findRoute(edges, st("a"), st("b")))
+
+        assertEquals(1, route.legs.size)
+        assertEquals(120L, route.totalSeconds)
+        assertEquals(listOf("a", "b"), route.stations.map { it.value })
+        assertEquals("rw-ab", route.legs.first().railwayId.value)
+    }
+
+    @Test
+    @DisplayName("chains multiple railways into a multi-leg route and sums seconds")
+    fun multiLeg() {
+        val edges = undirected("rw-ab", "a", "b", 60) + undirected("rw-bc", "b", "c", 90)
+        val route = rightOrFail(RouteFinder.findRoute(edges, st("a"), st("c")))
+
+        assertEquals(2, route.legs.size)
+        assertEquals(150L, route.totalSeconds)
+        assertEquals(listOf("a", "b", "c"), route.stations.map { it.value })
+    }
+
+    @Test
+    @DisplayName("prefers the shortest total time over fewer hops")
+    fun prefersShortestTime() {
+        // Direct a->c costs 1000; the two-hop a->b->c costs 20. Dijkstra must pick the cheaper.
+        val edges = undirected("rw-ac", "a", "c", 1000) +
+            undirected("rw-ab", "a", "b", 10) +
+            undirected("rw-bc", "b", "c", 10)
+        val route = rightOrFail(RouteFinder.findRoute(edges, st("a"), st("c")))
+
+        assertEquals(20L, route.totalSeconds)
+        assertEquals(listOf("a", "b", "c"), route.stations.map { it.value })
+    }
+
+    @Test
+    @DisplayName("treats railways as undirected: the reverse direction is routable")
+    fun reverseIsRoutable() {
+        val edges = undirected("rw-ab", "a", "b", 42)
+        val route = rightOrFail(RouteFinder.findRoute(edges, st("b"), st("a")))
+
+        assertEquals(1, route.legs.size)
+        assertEquals(42L, route.totalSeconds)
+        assertEquals(listOf("b", "a"), route.stations.map { it.value })
+    }
+
+    @Test
+    @DisplayName("carries the group through to each leg")
+    fun carriesGroup() {
+        val edges = undirected("rw-ab", "a", "b", 30, group = "main-line")
+        val route = rightOrFail(RouteFinder.findRoute(edges, st("a"), st("b")))
+
+        assertEquals("main-line", route.legs.first().group?.value)
+    }
+
+    @Test
+    @DisplayName("returns SameStation when from equals to")
+    fun sameStation() {
+        val edges = undirected("rw-ab", "a", "b", 10)
+        val result = RouteFinder.findRoute(edges, st("a"), st("a"))
+
+        assertTrue(result.isLeft())
+        assertEquals(RouteError.SameStation, (result as arrow.core.Either.Left).value)
+    }
+
+    @Test
+    @DisplayName("returns NoPath when the destination is in a disconnected component")
+    fun noPathDisconnected() {
+        val edges = undirected("rw-ab", "a", "b", 10) + undirected("rw-cd", "c", "d", 10)
+        val result = RouteFinder.findRoute(edges, st("a"), st("d"))
+
+        assertTrue(result.isLeft())
+        assertEquals(RouteError.NoPath, (result as arrow.core.Either.Left).value)
+    }
+
+    @Test
+    @DisplayName("returns NoPath when the origin has no edges at all")
+    fun noPathIsolatedOrigin() {
+        val edges = undirected("rw-bc", "b", "c", 10)
+        val result = RouteFinder.findRoute(edges, st("a"), st("c"))
+
+        assertTrue(result.isLeft())
+        assertEquals(RouteError.NoPath, (result as arrow.core.Either.Left).value)
+    }
+}


### PR DESCRIPTION
Closes #146. `/ar railway route` と `GET /route` を追加します。レールと徒歩を組み合わせた幾何グラフ上の A* 経路探索です。

（#145 マージに伴い旧 PR #147 が自動クローズされたため、base を master にして再作成したものです。内容は #147 と同一。）

## 変更内容

- **`RouteFinder`**（`route/`）— Bukkit / Koin 非依存の純粋ロジック。**レール辺**（`timeRequired` 秒）と**同一ワールド内の徒歩辺**（直線水平距離 ÷ 4.317 b/s）を組み合わせた幾何グラフ上で **A***（許容ヒューリスティック、丸め前の実数コストで探索）により最短経路を求める。レール未接続の駅どうしや現在地からでも徒歩で到達可能。異なるワールド間はレールのみ。
- **コマンド** `/ar railway route <from> <to>` / `/ar railway route <to>`（現在地から、単一 `@Subcommand`＋末尾 `@Optional`）。
- **HTTP API** `GET /route?from=&to=` → `RouteResponse`（サービストークン認証）。
- 多エージェント敵対的レビューで検出した 7 件（同名アリティ衝突・A* 非許容・500・非効率）を修正済み。
- **`RouteFinderTest` 18 ケース** ＋ エンドポイント 7 ケース。ドキュメント更新。

## 検証
- `./gradlew build` — **BUILD SUCCESSFUL**（compile + detekt + 全テスト）。
- ⚠️ コマンドの Bukkit 配線（lamp 登録・`Player`→`Origin`）と HTTP ワイヤー上シリアライズは実サーバーのみで検証可能。