### PR TITLE
♻️ Finish DataPaths migration & harden loaders + tests (#135, #131, #123, #126)

### DIFF
--- a/src/main/kotlin/dev/nikomaru/advancerailway/commands/CommandUtils.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/commands/CommandUtils.kt
@@ -10,26 +10,7 @@
 package dev.nikomaru.advancerailway.commands
 
 import arrow.core.Either
-import dev.nikomaru.advancerailway.AdvanceRailway
 import org.bukkit.command.CommandSender
-import java.io.File
-
-/**
- * `data/` 配下の各サブフォルダへのパスを一元化するヘルパ。
- *
- * コマンド実装のあちこちに散らばっていた
- * `dataFolder.resolve("data").resolve("groups"/"railways"/"stations")`
- * という重複したリテラルを 1 箇所に集約する。
- *
- * アクセサは computed（`get()`）にしており、クラスロード時に
- * [AdvanceRailway.plugin]（`lateinit`）へ触れないようにしている。
- */
-object DataPaths {
-    private val dataFolder: File get() = AdvanceRailway.plugin.dataFolder.resolve("data")
-    val groups: File get() = dataFolder.resolve("groups")
-    val railways: File get() = dataFolder.resolve("railways")
-    val stations: File get() = dataFolder.resolve("stations")
-}
 
 /**
  * [Either] の [Either.Right] を取り出す。[Either.Left] の場合は [msg] で生成した

--- a/src/main/kotlin/dev/nikomaru/advancerailway/commands/FileCommand.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/commands/FileCommand.kt
@@ -10,6 +10,7 @@
 package dev.nikomaru.advancerailway.commands
 
 import dev.nikomaru.advancerailway.AdvanceRailway
+import dev.nikomaru.advancerailway.file.DataPaths
 import dev.nikomaru.advancerailway.file.data.*
 import dev.nikomaru.advancerailway.utils.Utils.csv
 import dev.nikomaru.advancerailway.utils.Utils.json
@@ -65,7 +66,7 @@ class FileCommand: KoinComponent {
 
     @Subcommand("import")
     fun import(sender: CommandSender, dataType: DataType, fileName: String) {
-        val importFile = plugin.dataFolder.resolve("import").resolve(fileName)
+        val importFile = DataPaths.import.resolve(fileName)
         if (!importFile.exists()) {
             sender.sendRichMessage("Error: Import file not found: $fileName")
             return

--- a/src/main/kotlin/dev/nikomaru/advancerailway/commands/group/GroupInfoCommand.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/commands/group/GroupInfoCommand.kt
@@ -10,7 +10,7 @@
 package dev.nikomaru.advancerailway.commands.group
 
 import dev.nikomaru.advancerailway.AdvanceRailway
-import dev.nikomaru.advancerailway.commands.DataPaths
+import dev.nikomaru.advancerailway.file.DataPaths
 import dev.nikomaru.advancerailway.commands.getOrSend
 import dev.nikomaru.advancerailway.file.value.GroupId
 import dev.nikomaru.advancerailway.utils.GroupUtils

--- a/src/main/kotlin/dev/nikomaru/advancerailway/commands/group/GroupMainCommand.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/commands/group/GroupMainCommand.kt
@@ -10,7 +10,7 @@
 package dev.nikomaru.advancerailway.commands.group
 
 import dev.nikomaru.advancerailway.AdvanceRailway
-import dev.nikomaru.advancerailway.commands.DataPaths
+import dev.nikomaru.advancerailway.file.DataPaths
 import dev.nikomaru.advancerailway.file.FileLoader
 import dev.nikomaru.advancerailway.file.data.GroupData
 import dev.nikomaru.advancerailway.file.data.RailwayData

--- a/src/main/kotlin/dev/nikomaru/advancerailway/commands/railway/RailwayInfoCommand.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/commands/railway/RailwayInfoCommand.kt
@@ -10,7 +10,7 @@
 package dev.nikomaru.advancerailway.commands.railway
 
 import dev.nikomaru.advancerailway.AdvanceRailway
-import dev.nikomaru.advancerailway.commands.DataPaths
+import dev.nikomaru.advancerailway.file.DataPaths
 import dev.nikomaru.advancerailway.commands.getOrSend
 import dev.nikomaru.advancerailway.file.value.RailwayId
 import dev.nikomaru.advancerailway.utils.RailwayUtils

--- a/src/main/kotlin/dev/nikomaru/advancerailway/commands/railway/RailwayMainCommand.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/commands/railway/RailwayMainCommand.kt
@@ -12,7 +12,7 @@ package dev.nikomaru.advancerailway.commands.railway
 
 import dev.nikomaru.advancerailway.AdvanceRailway
 import dev.nikomaru.advancerailway.Point3D
-import dev.nikomaru.advancerailway.commands.DataPaths
+import dev.nikomaru.advancerailway.file.DataPaths
 import dev.nikomaru.advancerailway.file.FileLoader
 import dev.nikomaru.advancerailway.file.data.RailwayData
 import dev.nikomaru.advancerailway.file.type.LineType

--- a/src/main/kotlin/dev/nikomaru/advancerailway/commands/railway/RailwayRouteCommand.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/commands/railway/RailwayRouteCommand.kt
@@ -10,7 +10,7 @@
 package dev.nikomaru.advancerailway.commands.railway
 
 import arrow.core.Either
-import dev.nikomaru.advancerailway.AdvanceRailway
+import dev.nikomaru.advancerailway.file.DataPaths
 import dev.nikomaru.advancerailway.file.data.StationData
 import dev.nikomaru.advancerailway.file.value.GroupId
 import dev.nikomaru.advancerailway.file.value.IdValidation
@@ -32,8 +32,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import org.bukkit.command.CommandSender
 import org.bukkit.entity.Player
-import org.koin.core.component.KoinComponent
-import org.koin.core.component.inject
 import revxrsal.commands.annotation.Command
 import revxrsal.commands.annotation.Optional
 import revxrsal.commands.annotation.Subcommand
@@ -50,8 +48,7 @@ import revxrsal.commands.bukkit.annotation.CommandPermission
  */
 @Command("ar railway", "advancerailway railway")
 @CommandPermission("advancerailway.command.railway.read")
-class RailwayRouteCommand : KoinComponent {
-    val plugin: AdvanceRailway by inject()
+class RailwayRouteCommand {
 
     /**
      * 経路検索。
@@ -169,7 +166,7 @@ class RailwayRouteCommand : KoinComponent {
 
     /** data/{type}/ 配下の JSON ファイル名を、allowlist を満たす ID として列挙する。 */
     private fun listIds(type: String): List<String> =
-        plugin.dataFolder.resolve("data").resolve(type).listFiles()
+        DataPaths.of(type).listFiles()
             ?.filter { it.isFile && it.extension == "json" }
             ?.map { it.nameWithoutExtension }
             ?.filter { IdValidation.isValid(it) }

--- a/src/main/kotlin/dev/nikomaru/advancerailway/commands/station/StationInfoCommand.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/commands/station/StationInfoCommand.kt
@@ -10,7 +10,7 @@
 package dev.nikomaru.advancerailway.commands.station
 
 import dev.nikomaru.advancerailway.AdvanceRailway
-import dev.nikomaru.advancerailway.commands.DataPaths
+import dev.nikomaru.advancerailway.file.DataPaths
 import dev.nikomaru.advancerailway.commands.getOrSend
 import dev.nikomaru.advancerailway.file.value.StationId
 import dev.nikomaru.advancerailway.utils.StationUtils

--- a/src/main/kotlin/dev/nikomaru/advancerailway/commands/station/StationMainCommand.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/commands/station/StationMainCommand.kt
@@ -11,7 +11,7 @@ package dev.nikomaru.advancerailway.commands.station
 
 import dev.nikomaru.advancerailway.AdvanceRailway
 import dev.nikomaru.advancerailway.Point3D
-import dev.nikomaru.advancerailway.commands.DataPaths
+import dev.nikomaru.advancerailway.file.DataPaths
 import dev.nikomaru.advancerailway.file.FileLoader
 import dev.nikomaru.advancerailway.file.data.RailwayData
 import dev.nikomaru.advancerailway.file.data.StationData

--- a/src/main/kotlin/dev/nikomaru/advancerailway/file/DataPaths.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/file/DataPaths.kt
@@ -1,0 +1,51 @@
+/*
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
+ *
+ * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication along with this software.
+ * If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+package dev.nikomaru.advancerailway.file
+
+import dev.nikomaru.advancerailway.AdvanceRailway
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+import java.io.File
+
+/**
+ * プラグインデータフォルダ配下のパスを一元化するヘルパ。
+ *
+ * コマンド・ファイル永続化・ユーティリティ・MineAuth 連携のあちこちに散らばっていた
+ * `dataFolder.resolve("data").resolve("groups"/"railways"/"stations")` という重複したリテラルを
+ * 1 箇所に集約する。データフォルダ構成を変更する際にここだけを直せば済むようにするのが目的。
+ *
+ * [AdvanceRailway] は [StationUtils][dev.nikomaru.advancerailway.utils.StationUtils] などの
+ * 各 Utils と同様に Koin から解決する（`by inject()` は遅延評価のため、クラスロード時には触れない）。
+ * アクセサを computed（`get()`）にしているのも、初期化順序に依存しないようにするため。
+ */
+object DataPaths : KoinComponent {
+    private val plugin: AdvanceRailway by inject()
+
+    /** `data/` 直下。各種データフォルダの親。 */
+    private val dataFolder: File get() = plugin.dataFolder.resolve("data")
+
+    /** `data/groups/`。 */
+    val groups: File get() = dataFolder.resolve("groups")
+
+    /** `data/railways/`。 */
+    val railways: File get() = dataFolder.resolve("railways")
+
+    /** `data/stations/`。 */
+    val stations: File get() = dataFolder.resolve("stations")
+
+    /**
+     * `data/<type>/` を返す。サブフォルダ名を動的に受け取る呼び出し
+     * （例: `listIds("stations")` のような汎用処理）向け。
+     */
+    fun of(type: String): File = dataFolder.resolve(type)
+
+    /** `import/`（プラグインデータ直下、`data/` の外）。CSV/JSON 一括取り込み用。 */
+    val import: File get() = plugin.dataFolder.resolve("import")
+}

--- a/src/main/kotlin/dev/nikomaru/advancerailway/file/FileLoader.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/file/FileLoader.kt
@@ -9,7 +9,6 @@
 
 package dev.nikomaru.advancerailway.file
 
-import dev.nikomaru.advancerailway.AdvanceRailway
 import dev.nikomaru.advancerailway.file.loader.ConfigDataLoader
 import dev.nikomaru.advancerailway.file.loader.RailwayDataLoader
 import dev.nikomaru.advancerailway.file.loader.StationDataLoader
@@ -21,7 +20,6 @@ import xyz.jpenilla.squaremap.api.SimpleLayerProvider
 
 object FileLoader: KoinComponent {
     private val provider: SimpleLayerProvider by inject()
-    private val plugin: AdvanceRailway by inject()
 
     /**
      * マーカーの全消去→再構築を直列化するためのロック。
@@ -31,7 +29,7 @@ object FileLoader: KoinComponent {
     private val mapLoadMutex = Mutex()
 
     suspend fun load() = mapLoadMutex.withLock {
-        val importFolder = plugin.dataFolder.resolve("import")
+        val importFolder = DataPaths.import
         if (!importFolder.exists()) {
             importFolder.mkdirs()
         }

--- a/src/main/kotlin/dev/nikomaru/advancerailway/file/data/GroupData.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/file/data/GroupData.kt
@@ -9,16 +9,13 @@
 
 package dev.nikomaru.advancerailway.file.data
 
-import dev.nikomaru.advancerailway.AdvanceRailway
-import dev.nikomaru.advancerailway.AdvanceRailway.Companion.plugin
+import dev.nikomaru.advancerailway.file.DataPaths
 import dev.nikomaru.advancerailway.file.utils.ColorSerializer
 import dev.nikomaru.advancerailway.file.utils.writeAtomically
 import dev.nikomaru.advancerailway.file.value.GroupId
 import dev.nikomaru.advancerailway.utils.Utils.json
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
-import org.koin.core.component.KoinComponent
-import org.koin.core.component.inject
 import java.awt.Color
 
 @Serializable
@@ -26,16 +23,15 @@ data class GroupData(
     val groupId: GroupId,
     val name: String,
     val railwayColor: @Serializable(with = ColorSerializer::class) Color,
-): KoinComponent {
-    val plugin: AdvanceRailway by inject()
+) {
     fun save() {
-        val file = plugin.dataFolder.resolve("data").resolve("groups").resolve("${groupId.value}.json")
+        val file = DataPaths.groups.resolve("${groupId.value}.json")
         writeAtomically(file, json.encodeToString(this))
     }
 
     companion object {
         fun load(groupId: GroupId): GroupData {
-            val file = plugin.dataFolder.resolve("data").resolve("groups").resolve("${groupId.value}.json")
+            val file = DataPaths.groups.resolve("${groupId.value}.json")
             return json.decodeFromString(file.readText())
         }
     }

--- a/src/main/kotlin/dev/nikomaru/advancerailway/file/data/RailwayData.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/file/data/RailwayData.kt
@@ -9,9 +9,9 @@
 
 package dev.nikomaru.advancerailway.file.data
 
-import dev.nikomaru.advancerailway.AdvanceRailway
 import dev.nikomaru.advancerailway.Line3D
 import dev.nikomaru.advancerailway.Point3D
+import dev.nikomaru.advancerailway.file.DataPaths
 import dev.nikomaru.advancerailway.file.FileLoader
 import dev.nikomaru.advancerailway.file.type.LineType
 import dev.nikomaru.advancerailway.file.utils.WorldSerializer
@@ -23,8 +23,6 @@ import dev.nikomaru.advancerailway.utils.Utils.json
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import org.bukkit.World
-import org.koin.core.component.KoinComponent
-import org.koin.core.component.inject
 
 @Serializable
 data class RailwayData(
@@ -37,18 +35,17 @@ data class RailwayData(
     val startPoint: Point3D,
     val endPoint: Point3D,
     val directionPoint: Point3D
-): KoinComponent {
-    val plugin: AdvanceRailway by inject()
+) {
 
     suspend fun save() {
-        val file = plugin.dataFolder.resolve("data").resolve("railways").resolve("${id.value}.json")
+        val file = DataPaths.railways.resolve("${id.value}.json")
         writeAtomically(file, json.encodeToString(this))
         FileLoader.mapDataLoad()
     }
 
     companion object {
         fun load(id: RailwayId): RailwayData {
-            val file = AdvanceRailway.plugin.dataFolder.resolve("data").resolve("railways").resolve("${id.value}.json")
+            val file = DataPaths.railways.resolve("${id.value}.json")
             return json.decodeFromString(file.readText())
         }
     }

--- a/src/main/kotlin/dev/nikomaru/advancerailway/file/data/StationData.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/file/data/StationData.kt
@@ -9,9 +9,8 @@
 
 package dev.nikomaru.advancerailway.file.data
 
-import dev.nikomaru.advancerailway.AdvanceRailway
-import dev.nikomaru.advancerailway.AdvanceRailway.Companion.plugin
 import dev.nikomaru.advancerailway.Point3D
+import dev.nikomaru.advancerailway.file.DataPaths
 import dev.nikomaru.advancerailway.file.FileLoader
 import dev.nikomaru.advancerailway.file.utils.ColorSerializer
 import dev.nikomaru.advancerailway.file.utils.WorldSerializer
@@ -21,8 +20,6 @@ import dev.nikomaru.advancerailway.utils.Utils.json
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import org.bukkit.World
-import org.koin.core.component.KoinComponent
-import org.koin.core.component.inject
 import java.awt.Color
 import kotlin.random.Random
 
@@ -35,11 +32,10 @@ data class StationData(
     val point: Point3D,
     val overrideSize: Double?,
     val color: @Serializable(with = ColorSerializer::class) Color = defaultColor(stationId)
-): KoinComponent {
-    val plugin: AdvanceRailway by inject()
+) {
 
     suspend fun save() {
-        val file = plugin.dataFolder.resolve("data").resolve("stations").resolve("${stationId.value}.json")
+        val file = DataPaths.stations.resolve("${stationId.value}.json")
         writeAtomically(file, json.encodeToString(this))
         FileLoader.mapDataLoad()
     }
@@ -57,7 +53,7 @@ data class StationData(
         }
 
         fun load(stationId: StationId): StationData {
-            val file = plugin.dataFolder.resolve("data").resolve("stations").resolve("${stationId.value}.json")
+            val file = DataPaths.stations.resolve("${stationId.value}.json")
             return json.decodeFromString(file.readText())
         }
     }

--- a/src/main/kotlin/dev/nikomaru/advancerailway/file/loader/RailwayDataLoader.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/file/loader/RailwayDataLoader.kt
@@ -10,6 +10,7 @@
 package dev.nikomaru.advancerailway.file.loader
 
 import dev.nikomaru.advancerailway.AdvanceRailway
+import dev.nikomaru.advancerailway.file.DataPaths
 import dev.nikomaru.advancerailway.file.data.RailwayData
 import dev.nikomaru.advancerailway.file.type.LineType
 import dev.nikomaru.advancerailway.utils.Utils.json
@@ -27,8 +28,8 @@ import kotlin.math.ceil
 class RailwayDataLoader: KoinComponent {
     private val plugin: AdvanceRailway by inject()
     private val provider: SimpleLayerProvider by inject()
-    private val railwayDataFolder = plugin.dataFolder.resolve("data").resolve("railways")
-    private val groupDataFolder = plugin.dataFolder.resolve("data").resolve("groups")
+    private val railwayDataFolder = DataPaths.railways
+    private val groupDataFolder = DataPaths.groups
 
 
     suspend fun load() {
@@ -51,17 +52,36 @@ class RailwayDataLoader: KoinComponent {
                 LineType.UP_DOWN_LINE -> "<->"
                 else -> "->"
             }
+            // 参照先を 1 度だけ解決する。削除済み等で解決できない場合は警告を出し、
+            // ツールチップにリテラル "null" を出さないよう ID をプレースホルダとして表示する。
+            val fromData = data.fromStation.toData()
+            val toData = data.toStation.toData()
+            val groupData = data.group?.toData()
+            if (fromData == null || toData == null) {
+                plugin.logger.warning(
+                    "Railway '${data.id.value}' references missing station(s): " +
+                        "from=${data.fromStation.value}${if (fromData == null) " (missing)" else ""}, " +
+                        "to=${data.toStation.value}${if (toData == null) " (missing)" else ""}"
+                )
+            }
+            if (data.group != null && groupData == null) {
+                plugin.logger.warning(
+                    "Railway '${data.id.value}' references missing group: ${data.group.value}"
+                )
+            }
+            val fromName = fromData?.name ?: data.fromStation.value
+            val toName = toData?.name ?: data.toStation.value
             val option = MarkerOptions.builder().clickTooltip("""
-                行き先 : ${data.fromStation.toData()?.name} $arrow ${data.toStation.toData()?.name} </span><br/>
+                行き先 : $fromName $arrow $toName </span><br/>
                 所要時間 : 約 ${ceil(data.timeRequired / 6.0) / 10} 分 </span><br/>
-                ${data.group?.let { "${it.toData()?.name}" } ?: ""}
+                ${groupData?.name ?: ""}
             """.trimIndent())
             val random = Random()
             random.setSeed(data.group.hashCode().toLong())
             val randomColor = Color(
                 random.nextInt(256), random.nextInt(256), random.nextInt(256)
             )
-            val color = data.group?.let { it.toData()?.railwayColor ?: randomColor } ?: randomColor
+            val color = groupData?.railwayColor ?: randomColor
             option.fillColor(color)
             option.strokeColor(color)
             marker.markerOptions(option)

--- a/src/main/kotlin/dev/nikomaru/advancerailway/file/loader/StationDataLoader.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/file/loader/StationDataLoader.kt
@@ -10,6 +10,7 @@
 package dev.nikomaru.advancerailway.file.loader
 
 import dev.nikomaru.advancerailway.AdvanceRailway
+import dev.nikomaru.advancerailway.file.DataPaths
 import dev.nikomaru.advancerailway.file.data.ConfigData
 import dev.nikomaru.advancerailway.file.data.RailwayData
 import dev.nikomaru.advancerailway.file.data.StationData
@@ -28,8 +29,8 @@ class StationDataLoader: KoinComponent {
     private val plugin: AdvanceRailway by inject()
     private val provider: SimpleLayerProvider by inject()
     private val config: ConfigData by inject()
-    private val stationDataFolder = plugin.dataFolder.resolve("data").resolve("stations")
-    private val railwayDataFolder = plugin.dataFolder.resolve("data").resolve("railways")
+    private val stationDataFolder = DataPaths.stations
+    private val railwayDataFolder = DataPaths.railways
     private val joinedCount = hashMapOf<StationId, Int>()
 
     fun load() {

--- a/src/main/kotlin/dev/nikomaru/advancerailway/mineauth/RailwayApiHandler.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/mineauth/RailwayApiHandler.kt
@@ -9,8 +9,8 @@
 
 package dev.nikomaru.advancerailway.mineauth
 
-import dev.nikomaru.advancerailway.AdvanceRailway
 import dev.nikomaru.advancerailway.Point3D
+import dev.nikomaru.advancerailway.file.DataPaths
 import dev.nikomaru.advancerailway.file.data.GroupData
 import dev.nikomaru.advancerailway.file.data.RailwayData
 import dev.nikomaru.advancerailway.file.data.StationData
@@ -40,8 +40,6 @@ import dev.nikomaru.advancerailway.utils.StationUtils
 import arrow.core.Either
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import org.koin.core.component.KoinComponent
-import org.koin.core.component.inject
 import party.morino.mineauth.api.CallerType
 import party.morino.mineauth.api.annotations.Authenticated
 import party.morino.mineauth.api.annotations.Get
@@ -63,8 +61,7 @@ import java.io.File
  * ハンドラーは [kotlinx.serialization.Serializable] な DTO をそのまま返し、
  * JSON へのシリアライズは MineAuth 側が担う。
  */
-class RailwayApiHandler : KoinComponent {
-    private val plugin: AdvanceRailway by inject()
+class RailwayApiHandler {
 
     companion object {
         /** limit 未指定時に返す件数の既定値。 */
@@ -298,7 +295,7 @@ class RailwayApiHandler : KoinComponent {
 
     /** data/{type}/ 配下のフォルダ署名（ファイル名＋更新時刻）。 */
     private fun signature(type: String): String {
-        val folder = plugin.dataFolder.resolve("data").resolve(type)
+        val folder = DataPaths.of(type)
         val files = folder.listFiles { f: File -> f.isFile && f.extension == "json" }?.sortedBy { it.name }
             ?: return ""
         return files.joinToString("|") { "${it.name}:${it.lastModified()}" }
@@ -335,7 +332,7 @@ class RailwayApiHandler : KoinComponent {
      * data/{type}/ 配下の JSON ファイル名（拡張子なし）を ID として列挙する。
      */
     private suspend fun listIds(type: String): List<String> = withContext(Dispatchers.IO) {
-        val folder = plugin.dataFolder.resolve("data").resolve(type)
+        val folder = DataPaths.of(type)
         if (!folder.exists()) return@withContext emptyList()
         folder.listFiles(File::isFile)
             ?.filter { it.extension == "json" }

--- a/src/main/kotlin/dev/nikomaru/advancerailway/utils/GroupUtils.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/utils/GroupUtils.kt
@@ -12,6 +12,7 @@ package dev.nikomaru.advancerailway.utils
 import arrow.core.Either
 import dev.nikomaru.advancerailway.AdvanceRailway
 import dev.nikomaru.advancerailway.error.DataSearchError
+import dev.nikomaru.advancerailway.file.DataPaths
 import dev.nikomaru.advancerailway.file.data.GroupData
 import dev.nikomaru.advancerailway.file.value.GroupId
 import dev.nikomaru.advancerailway.utils.Utils.json
@@ -23,7 +24,7 @@ import org.koin.core.component.inject
 object GroupUtils: KoinComponent {
     val plugin: AdvanceRailway by inject()
     suspend fun getGroupData(groupId: GroupId): Either<DataSearchError, GroupData> = withContext(Dispatchers.IO) {
-        val folder = StationUtils.plugin.dataFolder.resolve("data").resolve("groups")
+        val folder = DataPaths.groups
         if (!folder.exists()) {
             folder.mkdirs()
             return@withContext Either.Left(DataSearchError.NOT_FOUND)

--- a/src/main/kotlin/dev/nikomaru/advancerailway/utils/RailwayUtils.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/utils/RailwayUtils.kt
@@ -18,6 +18,7 @@ import dev.nikomaru.advancerailway.Point3D
 import dev.nikomaru.advancerailway.data.InspectData
 import dev.nikomaru.advancerailway.error.DataSearchError
 import dev.nikomaru.advancerailway.error.RailTraceError
+import dev.nikomaru.advancerailway.file.DataPaths
 import dev.nikomaru.advancerailway.file.data.ConfigData
 import dev.nikomaru.advancerailway.file.data.RailwayData
 import dev.nikomaru.advancerailway.file.value.RailwayId
@@ -175,7 +176,7 @@ object RailwayUtils: KoinComponent {
 
     suspend fun getRailwayData(railwayId: RailwayId): Either<DataSearchError, RailwayData> =
         withContext(Dispatchers.IO) {
-            val folder = StationUtils.plugin.dataFolder.resolve("data").resolve("railways")
+            val folder = DataPaths.railways
             if (!folder.exists()) {
                 folder.mkdirs()
                 return@withContext Either.Left(DataSearchError.NOT_FOUND)

--- a/src/main/kotlin/dev/nikomaru/advancerailway/utils/StationUtils.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/utils/StationUtils.kt
@@ -14,6 +14,7 @@ import dev.nikomaru.advancerailway.AdvanceRailway
 import dev.nikomaru.advancerailway.error.DataSearchError
 import dev.nikomaru.advancerailway.file.DataPaths
 import dev.nikomaru.advancerailway.file.data.StationData
+import dev.nikomaru.advancerailway.file.value.IdValidation
 import dev.nikomaru.advancerailway.file.value.StationId
 import dev.nikomaru.advancerailway.utils.Utils.json
 import dev.nikomaru.advancerailway.utils.Utils.toPoint3D
@@ -32,13 +33,17 @@ object StationUtils: KoinComponent {
             folder.mkdirs()
             return@withContext Either.Left(DataSearchError.NOT_FOUND)
         }
+        // クリック位置のワールドが不明なら最寄り駅を判定できない。
+        val worldName = location.world?.name ?: return@withContext Either.Left(DataSearchError.NOT_FOUND)
         val files = folder.listFiles() ?: return@withContext Either.Left(DataSearchError.NOT_FOUND)
-        val station =
-            files.map { StationId(it.nameWithoutExtension) }.map { getStationData(it) }.filter { it.isRight() }
-                .map { it.getOrNull()!! }
-        val world = location.world //TODO 距離の計算を変更する ネザーの場合は8倍にする (nether distance scaling not yet implemented)
+        val stations = files
+            .filter { it.isFile && it.extension == "json" && IdValidation.isValid(it.nameWithoutExtension) }
+            .mapNotNull { getStationData(StationId(it.nameWithoutExtension)).getOrNull() }
+            // 最寄り駅は同一ワールド内でのみ判定する（別ディメンションの駅を誤って選ばないため）。
+            // 同一ワールド内では座標が 1:1 のため、ネザー等のスケーリング補正は不要。
+            .filter { it.world.name == worldName }
 
-        val nearest = station.minByOrNull { it.point.distanceTo2D(location.toPoint3D()) }
+        val nearest = stations.minByOrNull { it.point.distanceTo2D(location.toPoint3D()) }
             ?: return@withContext Either.Left(DataSearchError.NOT_FOUND)
         return@withContext Either.Right(nearest.stationId)
     }

--- a/src/main/kotlin/dev/nikomaru/advancerailway/utils/StationUtils.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/utils/StationUtils.kt
@@ -12,6 +12,7 @@ package dev.nikomaru.advancerailway.utils
 import arrow.core.Either
 import dev.nikomaru.advancerailway.AdvanceRailway
 import dev.nikomaru.advancerailway.error.DataSearchError
+import dev.nikomaru.advancerailway.file.DataPaths
 import dev.nikomaru.advancerailway.file.data.StationData
 import dev.nikomaru.advancerailway.file.value.StationId
 import dev.nikomaru.advancerailway.utils.Utils.json
@@ -26,7 +27,7 @@ object StationUtils: KoinComponent {
     val plugin: AdvanceRailway by inject()
 
     suspend fun nearStation(location: Location): Either<DataSearchError, StationId> = withContext(Dispatchers.IO) {
-        val folder = plugin.dataFolder.resolve("data").resolve("stations")
+        val folder = DataPaths.stations
         if (!folder.exists()) {
             folder.mkdirs()
             return@withContext Either.Left(DataSearchError.NOT_FOUND)
@@ -44,7 +45,7 @@ object StationUtils: KoinComponent {
 
     suspend fun getStationData(stationId: StationId): Either<DataSearchError, StationData> =
         withContext(Dispatchers.IO) {
-            val folder = plugin.dataFolder.resolve("data").resolve("stations")
+            val folder = DataPaths.stations
             if (!folder.exists()) {
                 folder.mkdirs()
                 return@withContext Either.Left(DataSearchError.NOT_FOUND)

--- a/src/main/kotlin/dev/nikomaru/advancerailway/utils/command/IdParser.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/utils/command/IdParser.kt
@@ -9,7 +9,7 @@
 
 package dev.nikomaru.advancerailway.utils.command
 
-import dev.nikomaru.advancerailway.AdvanceRailway
+import dev.nikomaru.advancerailway.file.DataPaths
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
@@ -17,8 +17,6 @@ import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.bukkit.command.CommandSender
-import org.koin.core.component.KoinComponent
-import org.koin.core.component.inject
 import revxrsal.commands.bukkit.BukkitCommandHandler
 import revxrsal.commands.bukkit.sender
 import revxrsal.commands.command.CommandActor
@@ -83,10 +81,9 @@ abstract class IdParser<T : Any>(
     private val idFactory: (String) -> T,
     /** JSON field holding the display name, or null if this entity type has no name. */
     private val nameField: String? = null,
-) : ValueParser<T>(), KoinComponent {
-    val plugin: AdvanceRailway by inject()
+) : ValueParser<T>() {
 
-    private val folder get() = plugin.dataFolder.resolve("data").resolve(subfolder)
+    private val folder get() = DataPaths.of(subfolder)
 
     // 補完はキーストローク毎に呼ばれるため、フォルダ署名でキャッシュし変化が無ければ再パースしない。
     @Volatile
@@ -118,9 +115,9 @@ abstract class IdParser<T : Any>(
 
     protected fun BukkitCommandHandler.registerIdParser() {
         // Note: do NOT call ensureDataFolder() here. This runs from setCommand(), which
-        // executes before Koin is started (setupKoin()), and folder access resolves the
-        // lazily-injected `plugin` via Koin. Data folders are created explicitly, after
-        // Koin startup, by AdvanceRailway.onEnableAsync().
+        // executes early during startup; folder access goes through DataPaths, which reads
+        // the lateinit AdvanceRailway.plugin. Data folders are created explicitly later,
+        // after plugin/Koin startup, by AdvanceRailway.onEnableAsync().
         autoCompleter.registerParameterSuggestions(
             idType,
         ) { args: List<String>, sender: CommandActor, command: ExecutableCommand ->

--- a/src/test/kotlin/dev/nikomaru/advancerailway/mineauth/RailwayApiHandlerTest.kt
+++ b/src/test/kotlin/dev/nikomaru/advancerailway/mineauth/RailwayApiHandlerTest.kt
@@ -12,6 +12,7 @@ package dev.nikomaru.advancerailway.mineauth
 import dev.nikomaru.advancerailway.AdvanceRailway
 import dev.nikomaru.advancerailway.Line3D
 import dev.nikomaru.advancerailway.Point3D
+import dev.nikomaru.advancerailway.error.DataSearchError
 import dev.nikomaru.advancerailway.file.data.GroupData
 import dev.nikomaru.advancerailway.file.data.RailwayData
 import dev.nikomaru.advancerailway.file.data.StationData
@@ -19,6 +20,8 @@ import dev.nikomaru.advancerailway.file.type.LineType
 import dev.nikomaru.advancerailway.file.value.GroupId
 import dev.nikomaru.advancerailway.file.value.RailwayId
 import dev.nikomaru.advancerailway.file.value.StationId
+import dev.nikomaru.advancerailway.utils.GroupUtils
+import dev.nikomaru.advancerailway.utils.RailwayUtils
 import dev.nikomaru.advancerailway.utils.StationUtils
 import dev.nikomaru.advancerailway.utils.Utils.json
 import io.mockk.every
@@ -389,6 +392,38 @@ class RailwayApiHandlerTest {
         val theEnd = server.getWorld("world_the_end")!!
         val result = StationUtils.nearStation(Location(theEnd, 0.0, 64.0, 0.0))
         assertNull(result.getOrNull())
+    }
+
+    // --- *Utils.get*Data の直接カバレッジ（NOT_FOUND / 破損ファイル分離）--------------------------------
+
+    @Test
+    @DisplayName("getStationData/getGroupData/getRailwayData return the stored entity")
+    fun getDataHappyPath() = runBlocking {
+        assertEquals("Central", StationUtils.getStationData(StationId("st01")).getOrNull()?.name)
+        assertEquals("Yamanote", GroupUtils.getGroupData(GroupId("g1")).getOrNull()?.name)
+        assertEquals("st01", RailwayUtils.getRailwayData(RailwayId("rw01")).getOrNull()?.fromStation?.value)
+    }
+
+    @Test
+    @DisplayName("get*Data returns NOT_FOUND for a missing id")
+    fun getDataNotFound() = runBlocking {
+        assertEquals(DataSearchError.NOT_FOUND, StationUtils.getStationData(StationId("nope")).leftOrNull())
+        assertEquals(DataSearchError.NOT_FOUND, GroupUtils.getGroupData(GroupId("nope")).leftOrNull())
+        assertEquals(DataSearchError.NOT_FOUND, RailwayUtils.getRailwayData(RailwayId("nope")).leftOrNull())
+    }
+
+    @Test
+    @DisplayName("getStationData maps a corrupt on-disk file to DESERIALIZATION_FAILED (crash isolation)")
+    fun getDataCorruptFile() = runBlocking {
+        // 破損ファイルは他テストへ漏らさないよう、このテスト内だけで作成・削除する。
+        val broken = dataFolder.resolve("data").resolve("stations").resolve("brokenst.json")
+        broken.writeText("{ this is not valid json")
+        try {
+            val result = StationUtils.getStationData(StationId("brokenst"))
+            assertEquals(DataSearchError.DESERIALIZATION_FAILED, result.leftOrNull())
+        } finally {
+            broken.delete()
+        }
     }
 
     @Test

--- a/src/test/kotlin/dev/nikomaru/advancerailway/mineauth/RailwayApiHandlerTest.kt
+++ b/src/test/kotlin/dev/nikomaru/advancerailway/mineauth/RailwayApiHandlerTest.kt
@@ -19,10 +19,12 @@ import dev.nikomaru.advancerailway.file.type.LineType
 import dev.nikomaru.advancerailway.file.value.GroupId
 import dev.nikomaru.advancerailway.file.value.RailwayId
 import dev.nikomaru.advancerailway.file.value.StationId
+import dev.nikomaru.advancerailway.utils.StationUtils
 import dev.nikomaru.advancerailway.utils.Utils.json
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
+import org.bukkit.Location
 import org.bukkit.World
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -70,6 +72,8 @@ class RailwayApiHandlerTest {
 
         server = MockBukkit.mock()
         world = server.addSimpleWorld("world")
+        // 駅の無いワールド（StationUtils.nearStation の NOT_FOUND ケース用）。
+        server.addSimpleWorld("world_the_end")
         // 別ワールド（経路探索のクロスワールド NoPath ケース用）。
         server.addSimpleWorld("world_nether")
 
@@ -358,6 +362,33 @@ class RailwayApiHandlerTest {
         }
         assertEquals(HttpStatus.NOT_FOUND, error.status)
         assertEquals("no_station", error.code)
+    }
+
+    // --- StationUtils.nearStation（RailClickEvent が使う最寄り駅判定）---------------------------------
+
+    @Test
+    @DisplayName("nearStation returns the closest station in the clicked location's world")
+    fun nearStationReturnsClosest() = runBlocking {
+        // (2,-3) は st01 (1,64,-3) に最も近い（y は無視）。
+        val result = StationUtils.nearStation(Location(world, 2.0, 64.0, -3.0))
+        assertEquals("st01", result.getOrNull()?.value)
+    }
+
+    @Test
+    @DisplayName("nearStation never matches a station in another dimension")
+    fun nearStationExcludesOtherWorld() = runBlocking {
+        // 別ワールド nt01 と同座標 (0,0) をオーバーワールドでクリックしても nt01 は候補外。
+        // 同一ワールドの最寄り st01 が返る。
+        val result = StationUtils.nearStation(Location(world, 0.0, 64.0, 0.0))
+        assertEquals("st01", result.getOrNull()?.value)
+    }
+
+    @Test
+    @DisplayName("nearStation returns NOT_FOUND when the clicked world has no stations")
+    fun nearStationNoStationInWorld() = runBlocking {
+        val theEnd = server.getWorld("world_the_end")!!
+        val result = StationUtils.nearStation(Location(theEnd, 0.0, 64.0, 0.0))
+        assertNull(result.getOrNull())
     }
 
     @Test


### PR DESCRIPTION
起票済みレビューissueのうち、**現行HEADでまだ有効かつ低リスクでユニットテスト検証可能な残作業**を実装しました。

大半のissue(#117/#122/#125/#127/#128/#129/#130/#132/#133/#136/#139/#140/#141/#142/#143 等)は、起票(2026-07-09)後の PR #155 等で**修正済みだがissueが未クローズ**であることを現行コードとの照合で確認しています。

## 変更内容

### #135 — DataPaths の移行完了
- `DataPaths` を `commands` → `file` パッケージへ移動し、file/utils/mineauth/commands から参照可能に
- 動的サブフォルダ用 `of(name)` と `import` を追加
- 残り ~17 箇所の `dataFolder.resolve("data").resolve(...)` リテラルを集約(loaders / data classes / *Utils / IdParser / RailwayApiHandler / RailwayRouteCommand)
- パス組み立てのためだけに残っていた `plugin`/`KoinComponent` ハンドルを除去

> ℹ️ `DataPaths` の plugin 解決を companion(`private set` でテスト不可)から **Koin `by inject()`** へ変更しました(`StationUtils` 等と統一)。起動シーケンス上 `setCommand`/`setEventHandlers` は `DataPaths` に触れず(最初の参照は `setupKoin` 後の `ensureCommandDataFolders`)、安全に確認済みです。代替案は companion を `internal set` にする方法でした — 判断が分かれる箇所としてメンテナのレビュー歓迎です。

### #131 — dangling reference のハードニング
- `RailwayDataLoader` で from/to 駅・グループ参照を **1度だけ**解決
- 参照先が欠落している場合は警告ログを出し、squaremap ツールチップにリテラル `null` ではなく **ID をプレースホルダ**表示

### #123残 — nearStation をワールド内に限定
- `StationUtils.nearStation` が全ワールドの駅を 2D 距離比較していたため、別ディメンションの駅が「最寄り」に選ばれ得た
- クリック位置と**同一ワールド**の駅のみ候補に(`RailwayApiHandler.nearestStation` と統一)。同一ワールド内は座標 1:1 のため、ネザー 8x スケーリングの TODO は不要となり削除
- `getOrNull()!!` を `mapNotNull` に置換、不正ファイル名をスキップ

### #126 — テスト拡充(部分)
- `StationUtils`/`GroupUtils`/`RailwayUtils.get*Data` の直接テスト(happy / NOT_FOUND / **破損ファイル→DESERIALIZATION_FAILED**)を追加。破損ファイル分離(#122 の修正)には初のテスト
- `nearStation` テスト3本(同一ワールド最寄り / クロスディメンション除外 / 駅なしワールド → NOT_FOUND)
- object singleton が plugin を JVM 単位でキャッシュする制約のため、既存の `RailwayApiHandlerTest`(PER_CLASS)へ co-locate

## 検証
`./gradlew build`(compile + test + detekt + spotless)green。

## 対象外(別途対応推奨)
- **#137**(mccoroutine 移行)/ **#120**(マーカー upsert+debounce): スレッド親和性・ライブマップ描画のランタイム変更のため、`./gradlew runServer` 実機検証とセットで 1 件ずつ別PR推奨
- **#126** の残り: commands/loader/listener のミューテーション系テストは、共有フィクスチャ汚染を避ける基盤整備が前提