### PR TITLE
✨ 経路表示で連続する同一路線の区間を1行にまとめる

### DIFF
--- a/src/main/kotlin/dev/nikomaru/advancerailway/commands/railway/RailwayRouteCommand.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/commands/railway/RailwayRouteCommand.kt
@@ -125,11 +125,13 @@ class RailwayRouteCommand {
             "<green>経路: <white>${esc(route.fromLabel)}</white> <gray>→</gray> <white>${esc(route.toLabel)}</white></green> " +
                 "<gray>(合計 ${route.totalMinutes} 分 / ${route.legCount} 区間)"
         )
-        route.legs.forEach { leg ->
-            val via = when (leg.mode) {
+        // 連続する同一路線の区間を 1 行にまとめて表示する。
+        RouteRenderer.groupLegs(route.legs).forEach { seg ->
+            val via = when (seg.mode) {
                 TravelMode.RAIL -> {
-                    val line = leg.lineLabel?.let { "<aqua>[${esc(it)}]</aqua>" } ?: "<gray>[路線]</gray>"
-                    val info = leg.railwayId
+                    val line = seg.lineLabel?.let { "<aqua>[${esc(it)}]</aqua>" } ?: "<gray>[路線]</gray>"
+                    // まとめ行（複数区間）は路線をまたぐため [詳細] を付けない。単一区間のみリンクを残す。
+                    val info = seg.railwayId
                         ?.let { " <click:run_command:/ar railway info ${it.value}><dark_gray>[詳細]</dark_gray></click>" }
                         ?: ""
                     "$line$info"
@@ -137,9 +139,11 @@ class RailwayRouteCommand {
 
                 TravelMode.WALK -> "<gray>徒歩</gray>"
             }
+            // 複数区間をまとめた行だけ区間数を併記する。
+            val time = if (seg.legCount > 1) "${seg.legCount}区間 / ${seg.minutes} 分" else "${seg.minutes} 分"
             sender.sendRichMessage(
-                "<dark_gray>${leg.index}.</dark_gray> <white>${esc(leg.fromLabel)}</white> " +
-                    "<yellow>→</yellow> <white>${esc(leg.toLabel)}</white> $via <gray>(${leg.minutes} 分)"
+                "<dark_gray>${seg.index}.</dark_gray> <white>${esc(seg.fromLabel)}</white> " +
+                    "<yellow>→</yellow> <white>${esc(seg.toLabel)}</white> $via <gray>($time)"
             )
         }
     }

--- a/src/main/kotlin/dev/nikomaru/advancerailway/route/RouteRenderer.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/route/RouteRenderer.kt
@@ -27,7 +27,33 @@ data class RenderedLeg(
     val lineLabel: String?,
     /** レール区間の路線 ID（`/ar railway info` へのリンク用）。徒歩区間は `null`。 */
     val railwayId: RailwayId?,
+    /** レール区間の路線（グループ）ID。まとめ表示のグルーピングキー。徒歩区間・無所属レールは `null`。 */
+    val group: GroupId?,
+    /** この区間の所要時間（秒）。まとめ表示で合算するため保持する。 */
+    val timeSeconds: Long,
     /** この区間の所要時間（分、小数第 1 位）。 */
+    val minutes: Double,
+)
+
+/**
+ * 表示用に、連続する同一路線のレール区間を 1 つにまとめたセグメント。
+ * 徒歩区間・無所属レール（路線 ID があってもグループ未設定）の区間は、それぞれ 1 セグメントとして残す。
+ */
+data class RenderedSegment(
+    /** 1 始まりのセグメント番号。 */
+    val index: Int,
+    /** セグメント先頭の出発地表示名。 */
+    val fromLabel: String,
+    /** セグメント末尾の到着駅表示名。 */
+    val toLabel: String,
+    val mode: TravelMode,
+    /** レールセグメントの路線名。徒歩・無所属レールは `null`。 */
+    val lineLabel: String?,
+    /** 単一区間のセグメントのときのみ路線 ID（`[詳細]` リンク用）。複数区間をまとめた場合は `null`。 */
+    val railwayId: RailwayId?,
+    /** このセグメントにまとめた区間（レッグ）数。 */
+    val legCount: Int,
+    /** セグメント全体の所要時間（分、小数第 1 位）。区間ごとの秒を合算してから丸める。 */
     val minutes: Double,
 )
 
@@ -73,6 +99,8 @@ object RouteRenderer {
                 mode = leg.mode,
                 lineLabel = leg.group?.let { groupName(it)?.takeIf(String::isNotBlank) ?: it.value },
                 railwayId = leg.railwayId,
+                group = leg.group,
+                timeSeconds = leg.timeSeconds,
                 minutes = minutes(leg.timeSeconds),
             )
         }
@@ -83,5 +111,43 @@ object RouteRenderer {
             legCount = legs.size,
             legs = legs,
         )
+    }
+
+    /**
+     * 連続する同一路線（同一グループ）のレール区間を 1 セグメントにまとめる。
+     *
+     * まとめ条件は「両区間ともレール」かつ「両区間とも同一の非 null グループ」。
+     * 徒歩区間や、グループ未設定のレール区間（路線名を持たない区間）は、それぞれ独立したセグメントにする。
+     * まとめた区間の所要時間は、各区間の秒を合算してから丸めることで丸め誤差の累積を防ぐ。
+     *
+     * @param legs [render] が返した区間リスト（[RenderedRoute.legs]）。
+     * @return 路線ごとにまとめた表示用セグメント列（番号は 1 から振り直す）。
+     */
+    fun groupLegs(legs: List<RenderedLeg>): List<RenderedSegment> {
+        val groups = mutableListOf<MutableList<RenderedLeg>>()
+        for (leg in legs) {
+            val current = groups.lastOrNull()
+            val mergeable = current != null &&
+                leg.mode == TravelMode.RAIL &&
+                current.last().mode == TravelMode.RAIL &&
+                leg.group != null &&
+                current.last().group == leg.group
+            if (mergeable) current!!.add(leg) else groups.add(mutableListOf(leg))
+        }
+        return groups.mapIndexed { index, group ->
+            val first = group.first()
+            val last = group.last()
+            RenderedSegment(
+                index = index + 1,
+                fromLabel = first.fromLabel,
+                toLabel = last.toLabel,
+                mode = first.mode,
+                lineLabel = first.lineLabel,
+                // 単一区間のときだけ [詳細] リンク用の路線 ID を残す。
+                railwayId = group.singleOrNull()?.railwayId,
+                legCount = group.size,
+                minutes = minutes(group.sumOf { it.timeSeconds }),
+            )
+        }
     }
 }

--- a/src/test/kotlin/dev/nikomaru/advancerailway/route/RouteRendererTest.kt
+++ b/src/test/kotlin/dev/nikomaru/advancerailway/route/RouteRendererTest.kt
@@ -1,0 +1,114 @@
+/*
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
+ *
+ * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication along with this software.
+ * If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+package dev.nikomaru.advancerailway.route
+
+import dev.nikomaru.advancerailway.file.value.GroupId
+import dev.nikomaru.advancerailway.file.value.RailwayId
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+/**
+ * [RouteRenderer.groupLegs] のまとめ表示ロジックの単体テスト。
+ * Bukkit / Koin に依存しない純粋ロジックなので、[RenderedLeg] を直接組んで検証する。
+ */
+class RouteRendererTest {
+
+    private var counter = 0
+
+    /** テスト用の区間を組む。既定はレール区間。 */
+    private fun leg(
+        from: String,
+        to: String,
+        seconds: Long,
+        group: String?,
+        railway: String? = "rw${counter++}",
+        mode: TravelMode = TravelMode.RAIL,
+    ): RenderedLeg = RenderedLeg(
+        index = counter,
+        fromLabel = from,
+        toLabel = to,
+        mode = mode,
+        lineLabel = group,
+        railwayId = railway?.let { RailwayId(it) },
+        group = group?.let { GroupId(it) },
+        timeSeconds = seconds,
+        minutes = RouteRenderer.minutes(seconds),
+    )
+
+    @Test
+    @DisplayName("連続する同一路線のレール区間を 1 セグメントにまとめる")
+    fun mergesConsecutiveSameLine() {
+        val legs = listOf(
+            leg("岩間", "青原", 48, "seika"),
+            leg("青原", "城下町", 60, "seika"),
+            leg("城下町", "葉吹", 60, "seika"),
+        )
+
+        val segments = RouteRenderer.groupLegs(legs)
+
+        assertEquals(1, segments.size)
+        val seg = segments.first()
+        assertEquals(1, seg.index)
+        assertEquals("岩間", seg.fromLabel)
+        assertEquals("葉吹", seg.toLabel)
+        assertEquals(3, seg.legCount)
+        assertEquals("seika", seg.lineLabel)
+        // 秒を合算してから丸める: ceil(168 / 6) / 10 = 2.8
+        assertEquals(2.8, seg.minutes)
+        // まとめ行は路線をまたぐため railwayId を持たない（[詳細] リンクなし）。
+        assertNull(seg.railwayId)
+    }
+
+    @Test
+    @DisplayName("異なる路線・徒歩は別セグメントに分かれ、番号は振り直される")
+    fun splitsDifferentLinesAndWalks() {
+        val legs = listOf(
+            leg("A", "B", 60, "line1"),
+            leg("B", "C", 60, "line2"),
+            leg("C", "D", 30, group = null, railway = null, mode = TravelMode.WALK),
+            leg("D", "E", 60, "line2"),
+        )
+
+        val segments = RouteRenderer.groupLegs(legs)
+
+        assertEquals(4, segments.size)
+        assertEquals(listOf(1, 2, 3, 4), segments.map { it.index })
+        assertEquals(TravelMode.WALK, segments[2].mode)
+        assertNull(segments[2].lineLabel)
+        // line2 は非連続なのでまとめない。
+        assertEquals("line2", segments[1].lineLabel)
+        assertEquals("line2", segments[3].lineLabel)
+    }
+
+    @Test
+    @DisplayName("単一区間のセグメントは railwayId（[詳細] リンク用）を残す")
+    fun singleLegKeepsRailwayId() {
+        val segments = RouteRenderer.groupLegs(listOf(leg("A", "B", 114, "line", railway = "rw01")))
+
+        assertEquals(1, segments.size)
+        assertEquals("rw01", segments.first().railwayId?.value)
+        assertEquals(1, segments.first().legCount)
+    }
+
+    @Test
+    @DisplayName("グループ未設定（無所属）のレール区間は連続していてもまとめない")
+    fun doesNotMergeUnaffiliatedRail() {
+        val legs = listOf(
+            leg("A", "B", 60, group = null),
+            leg("B", "C", 60, group = null),
+        )
+
+        val segments = RouteRenderer.groupLegs(legs)
+
+        assertEquals(2, segments.size)
+    }
+}


### PR DESCRIPTION
## 概要

`/ar railway route` の経路表示を路線単位に集約します。連続する同一路線（同一グループ）のレール区間を 1 行にまとめ、`N区間 / 合計分` の形式で表示します。長距離経路で区間が数十行になっていたのを大幅に短縮します。

### Before（例: 29 区間がそのまま 29 行）
```
1. 東ボーダーライン → ネイチャウド村 [路線] [詳細] (4.0 分)
...
4. 岩間 → 青原 [聖花線] [詳細] (0.8 分)
5. 青原 → Unbekannt城下町 [聖花線] [詳細] (1.0 分)
...（聖花線だけで 7 行）
```

### After（10 行に集約）
```
経路: 東ボーダーライン → 酩酊街 (合計 58.1 分 / 29 区間)
1. 東ボーダーライン → ネイチャウド村 [路線] [詳細] (4.0 分)
2. ネイチャウド村 → 水雫（みずな） [水雫支線] [詳細] (14.2 分)
3. 水雫（みずな） → 岩間 徒歩 (0.9 分)
4. 岩間 → 東もりもと [聖花線] (7区間 / 8.0 分)
5. 東もりもと → もりもと [もりもと中央線] (2区間 / 0.9 分)
6. もりもと → うみもとうだい [うみもと線] (4区間 / 3.2 分)
7. うみもとうだい → 築別（ちくべつ） [森元森林鉄道] [詳細] (1.9 分)
8. 築別（ちくべつ） → 雪華郷 [迷大鉄道] (7区間 / 21.6 分)
9. 雪華郷 → 雪華郷広場 徒歩 (1.8 分)
10. 雪華郷広場 → 酩酊街 [雪原Line] (4区間 / 2.7 分)
```

## 仕様

- **まとめ条件**: 両区間ともレール かつ 同一の非 null グループのときだけ連結。
- **まとめないもの**: 徒歩区間、グループ未設定（無所属）のレール区間は 1 区間ずつ残す。
- **所要時間**: 各区間の秒を合算してから丸め、区間ごとの丸め誤差の累積を防ぐ。
- **`[詳細]` リンク**: 路線をまたぐまとめ行では省略し、単一区間の行のみ残す。
- **ヘッダの総区間数**（`/ 29 区間`）は据え置き。

## 変更点

- `RouteRenderer`: `RenderedSegment` 型と純粋関数 `groupLegs()` を追加。`RenderedLeg` に `group` / `timeSeconds` を追加。
- `RailwayRouteCommand`: 表示を `groupLegs()` 経由に変更。
- **HTTP API（`RailwayApiHandler` / DTO）は無変更** — レスポンスは従来どおり区間ごとの詳細を返す（まとめは in-game 表示のみ）。

## テスト

- 新規 `RouteRendererTest`（連続まとめ / 別路線・徒歩での分割＆番号振り直し / 単一区間の `railwayId` 保持 / 無所属レールの非マージ）— 全 PASS。
- 既存 `route.*`（`RealDataRouteTest`・`RouteFinderTest`）— PASS。