### PR TITLE
🔐 Wire AWS secrets to Bitwarden Secrets Manager in CI

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -11,8 +11,6 @@ permissions:
   attestations: write
 
 env:
-  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
   AWS_EC2_METADATA_DISABLED: true
   AWS_REGION: auto
   AWS_CLI_FILE_ENCODING: UTF-8
@@ -184,6 +182,15 @@ jobs:
           cp -r ./artifacts/gradle-artifacts/detekt ./upload/ || echo "No Detekt reports"
           mkdir -p ./upload/docs
           mv ./artifacts/docs-artifacts/* ./upload/docs/ || echo "No docs artifacts"
+
+      # Bitwarden Secrets Manager から S3 アップロード用の AWS 認証情報を取得する
+      - name: Fetch secrets from Bitwarden Secrets Manager
+        uses: bitwarden/sm-action@v2
+        with:
+          access_token: ${{ secrets.NIKOMARU_BITWARDEN_SECRET_MANAGER_ACCESS_TOKEN }}
+          secrets: |
+            37e4d53a-a898-4e9f-b067-b49900deaf4f > AWS_ACCESS_KEY_ID
+            4d92b739-40fc-467f-97fa-b49900deb52c > AWS_SECRET_ACCESS_KEY
 
       - name: Upload to S3 (parallel)
         run: |


### PR DESCRIPTION
## Summary
- Fetch the S3 upload `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` from Bitwarden Secrets Manager (BSM) via `bitwarden/sm-action@v2` in `preview.yml`'s `upload-s3` job, using the org-level `NIKOMARU_BITWARDEN_SECRET_MANAGER_ACCESS_TOKEN` secret, instead of GitHub repo secrets.
- `S3_UPLOAD_BUCKET` / `S3_ENDPOINT` stay as GitHub secrets (not in BSM). This repo has no Pelican deploy workflow.

## Test plan
- [ ] `preview.yml` (`upload-s3` job) succeeds on the next PR preview run