### PR TITLE
✨ Add --rail-only flag to railway route limiting transfers to 20s walks

### DIFF
--- a/src/main/kotlin/dev/nikomaru/advancerailway/AdvanceRailway.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/AdvanceRailway.kt
@@ -121,6 +121,9 @@ open class AdvanceRailway: SuspendingJavaPlugin() {
         }
 
         commandManager.settings().set(ManagerSetting.ALLOW_UNSAFE_REGISTRATION, true)
+        // フラグを最後のリテラル直後から解析させる。これが無いと、省略可能引数の後ろに置いたフラグ
+        // （例: /ar railway route <to> --rail-only）が省略可能引数のパーサーに食われてしまう。
+        commandManager.settings().set(ManagerSetting.LIBERAL_FLAG_PARSING, true)
 
         // ID・座標のカスタムパーサを登録する（補完＝表示名、解決＝名前 or ID）。
         with(commandManager.parserRegistry()) {

--- a/src/main/kotlin/dev/nikomaru/advancerailway/commands/railway/RailwayRouteCommand.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/commands/railway/RailwayRouteCommand.kt
@@ -35,6 +35,7 @@ import org.bukkit.entity.Player
 import org.incendo.cloud.annotations.Argument
 import org.incendo.cloud.annotations.Command
 import org.incendo.cloud.annotations.CommandDescription
+import org.incendo.cloud.annotations.Flag
 import org.incendo.cloud.annotations.Permission
 
 /**
@@ -45,6 +46,10 @@ import org.incendo.cloud.annotations.Permission
  *
  * 全路線（レール）と、同一ワールド内の徒歩移動を組み合わせた幾何グラフを [RouteFinder] に渡し、
  * A* で最短経路を求める。レールでつながっていない駅どうしや現在地からでも徒歩で到達できる。
+ *
+ * `--rail-only`（`-r`）フラグを付けると、駅間の徒歩（乗り換え・目的駅への徒歩）を
+ * [RouteFinder.RAIL_ONLY_MAX_WALK_SECONDS]（徒歩 20 秒）以内に制限し、できる限り鉄道だけの経路を探す。
+ * 現在地から最初の駅までの徒歩は制限しない。
  */
 @Command("ar|advancerailway railway")
 class RailwayRouteCommand {
@@ -57,6 +62,9 @@ class RailwayRouteCommand {
      * 引数が 1 つのときは末尾省略として現在地を起点にする（[second] が null）。
      * 2 つのときは `first` を出発駅、[second] を到着駅として扱う。
      * Cloud では任意引数 `[second]` を末尾に置くことで両形式を 1 メソッドで受ける。
+     *
+     * `--rail-only` は presence フラグ。省略可能引数の後ろでも解析できるよう、
+     * マネージャ側で [org.incendo.cloud.setting.ManagerSetting.LIBERAL_FLAG_PARSING] を有効にしている。
      */
     @Command("route <first> [second]")
     @CommandDescription("2 駅間（または現在地から）の最短経路を表示します")
@@ -65,6 +73,11 @@ class RailwayRouteCommand {
         sender: CommandSender,
         @Argument("first") first: StationId,
         @Argument("second") second: StationId?,
+        @Flag(
+            value = "rail-only",
+            aliases = ["r"],
+            description = "駅間の徒歩を 20 秒以内に制限し、できる限り鉄道だけの経路を探します",
+        ) railOnly: Boolean,
     ) {
         val stationData = loadAllStationData()
         val stations = stationData.map { it.toNode() }
@@ -80,7 +93,7 @@ class RailwayRouteCommand {
                 return
             }
             val origin = Waypoint.Origin(player.location.world.name, player.location.toPoint3D())
-            search(sender, stations, stationNames, "現在地", origin, toNode)
+            search(sender, stations, stationNames, "現在地", origin, toNode, railOnly)
         } else {
             // route <from> <to>: 駅から駅へ。
             val fromNode = stations.find { it.id == first } ?: run {
@@ -92,7 +105,7 @@ class RailwayRouteCommand {
                 return
             }
             val originLabel = stationNames[first]?.takeIf { it.isNotBlank() } ?: first.value
-            search(sender, stations, stationNames, originLabel, Waypoint.Station(fromNode), toNode)
+            search(sender, stations, stationNames, originLabel, Waypoint.Station(fromNode), toNode, railOnly)
         }
     }
 
@@ -103,16 +116,23 @@ class RailwayRouteCommand {
         originLabel: String,
         from: Waypoint,
         to: StationNode,
+        railOnly: Boolean,
     ) {
         val railways = loadAllRailways()
         val groupNames = loadGroupNames()
-        when (val result = RouteFinder.findRoute(stations, railways, from, to)) {
+        val maxWalkSeconds = if (railOnly) RouteFinder.RAIL_ONLY_MAX_WALK_SECONDS else null
+        when (val result = RouteFinder.findRoute(stations, railways, from, to, maxWalkSeconds = maxWalkSeconds)) {
             is Either.Left -> when (result.value) {
                 RouteError.SameStation ->
                     sender.sendRichMessage("<red>出発駅と到着駅が同じです。")
 
-                RouteError.NoPath ->
-                    sender.sendRichMessage("<red>${stationNames[to.id] ?: to.id.value} への経路が見つかりませんでした。")
+                RouteError.NoPath -> {
+                    val hint =
+                        if (railOnly) "<gray>（--rail-only 指定中: 徒歩 20 秒以内の乗り換えでは到達できません）" else ""
+                    sender.sendRichMessage(
+                        "<red>${stationNames[to.id] ?: to.id.value} への経路が見つかりませんでした。$hint"
+                    )
+                }
             }
 
             is Either.Right -> {

--- a/src/main/kotlin/dev/nikomaru/advancerailway/domain/route/RouteFinder.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/domain/route/RouteFinder.kt
@@ -104,6 +104,7 @@ sealed interface RouteError {
  * - **徒歩辺**: 同一ワールドの任意のノード間を直線水平距離（[Point3D.distanceTo2D]）÷ [walkSpeed] 秒で結ぶ。
  *   これにより、レールで直接つながっていない駅どうしや現在地からでも「歩いて」到達できる。
  *   異なるワールド間は徒歩不可（座標系が異なるため）。
+ *   `maxWalkSeconds` を指定すると駅間の徒歩辺をその所要時間以内に制限できる（レール優先モード）。
  *
  * ヒューリスティックは「終点までの直線距離 ÷ グラフ内の最大移動速度」。どの辺も
  * 「直線変位 ÷ 最大速度」より速くは進めないため許容的（admissible）であり、A* は最短経路を保証する。
@@ -114,6 +115,12 @@ object RouteFinder {
 
     /** Minecraft の既定の歩行速度（ブロック / 秒）。 */
     const val DEFAULT_WALK_SPEED: Double = 4.317
+
+    /**
+     * レール優先（`--rail-only`）モードで許容する駅間徒歩の最大所要時間（秒）。
+     * 徒歩 20 秒以内で移動できる乗り換え・目的駅への徒歩だけを許し、それ以上の徒歩を禁止する。
+     */
+    const val RAIL_ONLY_MAX_WALK_SECONDS: Double = 20.0
 
     /** 現在地ノードの内部キー。ID の allowlist（`[A-Za-z0-9_-]`）に含まれない文字を使い駅と衝突させない。 */
     private const val ORIGIN_KEY = "@origin"
@@ -143,6 +150,9 @@ object RouteFinder {
      * @param from 起点（駅または現在地）。
      * @param to 終点となる駅。
      * @param walkSpeed 歩行速度（ブロック / 秒）。
+     * @param maxWalkSeconds 駅から駅への徒歩辺を張る最大所要時間（秒）。`null` なら無制限。
+     *   起点が現在地（[Waypoint.Origin]）の場合、現在地から駅への徒歩には適用しない
+     *   （適用すると駅の近くに居ない限り経路が引けなくなるため）。
      */
     fun findRoute(
         stations: List<StationNode>,
@@ -150,6 +160,7 @@ object RouteFinder {
         from: Waypoint,
         to: StationNode,
         walkSpeed: Double = DEFAULT_WALK_SPEED,
+        maxWalkSeconds: Double? = null,
     ): Either<RouteError, Route> {
         val fromStationId = (from as? Waypoint.Station)?.node?.id
         if (fromStationId != null && fromStationId == to.id) return RouteError.SameStation.left()
@@ -181,7 +192,9 @@ object RouteFinder {
             val current = nodeByKey.getValue(key)
             val baseG = gScore.getValue(key)
 
-            for ((neighbor, incomingEdge) in neighbors(current, stationNodes, nodeByKey, railAdjacency, walkSpeed)) {
+            for ((neighbor, incomingEdge) in neighbors(
+                current, stationNodes, nodeByKey, railAdjacency, walkSpeed, maxWalkSeconds
+            )) {
                 if (neighbor.key in settled) continue
                 val tentative = baseG + incomingEdge.cost
                 if (tentative < (gScore[neighbor.key] ?: Double.MAX_VALUE)) {
@@ -227,6 +240,7 @@ object RouteFinder {
         nodeByKey: Map<String, Node>,
         railAdjacency: Map<String, List<RailEdge>>,
         walkSpeed: Double,
+        maxWalkSeconds: Double?,
     ): List<Pair<Node, Incoming>> {
         val result = ArrayList<Pair<Node, Incoming>>()
 
@@ -250,13 +264,16 @@ object RouteFinder {
         for (neighbor in stationNodes) {
             if (neighbor.key == current.key) continue
             if (neighbor.world != current.world) continue
+            val walkSeconds = current.point.distanceTo2D(neighbor.point) / walkSpeed
+            // 駅間の徒歩は maxWalkSeconds 以内に制限する（現在地からの徒歩は制限しない）。
+            if (maxWalkSeconds != null && current.stationId != null && walkSeconds > maxWalkSeconds) continue
             result += neighbor to Incoming(
                 fromKey = current.key,
                 mode = TravelMode.WALK,
                 railwayId = null,
                 fromStation = current.stationId,
                 toStation = neighbor.stationId!!, // stationNodes は必ず駅。
-                cost = current.point.distanceTo2D(neighbor.point) / walkSpeed,
+                cost = walkSeconds,
                 group = null,
             )
         }

--- a/src/test/kotlin/dev/nikomaru/advancerailway/domain/route/RealDataRouteTest.kt
+++ b/src/test/kotlin/dev/nikomaru/advancerailway/domain/route/RealDataRouteTest.kt
@@ -172,6 +172,26 @@ class RealDataRouteTest {
     }
 
     @Test
+    @DisplayName("rail-only mode (walk <= 20 seconds) routes fti -> akmt with every walk leg within the limit")
+    fun railOnlyRoute() {
+        val result = RouteFinder.findRoute(
+            stations, railways, Waypoint.Station(node("fti")), node("akmt"),
+            maxWalkSeconds = RouteFinder.RAIL_ONLY_MAX_WALK_SECONDS,
+        )
+        assertInstanceOf(Either.Right::class.java, result, "expected a rail-only route but got $result")
+        val route = (result as Either.Right).value
+
+        assertTrue(route.legs.isNotEmpty())
+        // 徒歩区間が残る場合も、すべて 1 分以内の乗り換えでなければならない。
+        route.legs.filter { it.mode == TravelMode.WALK }.forEach { leg ->
+            assertTrue(
+                leg.timeSeconds <= RouteFinder.RAIL_ONLY_MAX_WALK_SECONDS.toLong(),
+                "walk leg to ${leg.to.value} takes ${leg.timeSeconds}s, over the rail-only limit",
+            )
+        }
+    }
+
+    @Test
     @DisplayName("routes between two rail-connected stations of the real network")
     fun directRailNeighbours() {
         // Pick a real railway whose endpoints are both known stations, and route between them.

--- a/src/test/kotlin/dev/nikomaru/advancerailway/domain/route/RouteFinderTest.kt
+++ b/src/test/kotlin/dev/nikomaru/advancerailway/domain/route/RouteFinderTest.kt
@@ -203,6 +203,69 @@ class RouteFinderTest {
     }
 
     @Test
+    @DisplayName("maxWalkSeconds rejects a walking transfer longer than the limit between two rail segments")
+    fun maxWalkSecondsBlocksLongTransfer() {
+        val a = station("a", 0.0, 0.0)
+        val b = station("b", 1000.0, 0.0)
+        val c = station("c", 1500.0, 0.0) // 500 blocks from b -> ~116s walk, over the 60s limit
+        val d = station("d", 2500.0, 0.0)
+        val rails = listOf(rail("ab", a, b, 10), rail("cd", c, d, 10))
+
+        // Without the limit, the b -> c walk bridges the two rail segments.
+        rightOrFail(RouteFinder.findRoute(listOf(a, b, c, d), rails, Waypoint.Station(a), d))
+        // With a 60-second limit, the ~116s transfer is forbidden and no path remains.
+        assertEquals(
+            RouteError.NoPath,
+            leftOf(RouteFinder.findRoute(listOf(a, b, c, d), rails, Waypoint.Station(a), d, maxWalkSeconds = 60.0))
+        )
+    }
+
+    @Test
+    @DisplayName("maxWalkSeconds rejects walking the last stretch to the destination")
+    fun maxWalkSecondsBlocksFinalWalk() {
+        val a = station("a", 0.0, 0.0)
+        val b = station("b", 1000.0, 0.0)
+        val c = station("c", 1500.0, 0.0) // destination, only reachable by a ~116s walk
+        val rails = listOf(rail("ab", a, b, 10))
+
+        assertEquals(
+            RouteError.NoPath,
+            leftOf(RouteFinder.findRoute(listOf(a, b, c), rails, Waypoint.Station(a), c, maxWalkSeconds = 60.0))
+        )
+    }
+
+    @Test
+    @DisplayName("maxWalkSeconds still allows a transfer walk within the limit")
+    fun maxWalkSecondsAllowsShortTransfer() {
+        val a = station("a", 0.0, 0.0)
+        val b = station("b", 1000.0, 0.0)
+        val b2 = station("b2", 1100.0, 0.0) // 100 blocks from b -> ~23s walk, within the 60s limit
+        val c = station("c", 2100.0, 0.0)
+        val rails = listOf(rail("ab", a, b, 10), rail("b2c", b2, c, 10))
+
+        val route = rightOrFail(
+            RouteFinder.findRoute(listOf(a, b, b2, c), rails, Waypoint.Station(a), c, maxWalkSeconds = 60.0)
+        )
+        assertEquals(listOf(TravelMode.RAIL, TravelMode.WALK, TravelMode.RAIL), route.legs.map { it.mode })
+        assertEquals(listOf("a", "b", "b2", "c"), route.stations.map { it.value })
+    }
+
+    @Test
+    @DisplayName("maxWalkSeconds does not restrict the walk from the origin to the first station")
+    fun maxWalkSecondsExemptsOrigin() {
+        val a = station("a", 500.0, 0.0)
+        val b = station("b", 2000.0, 0.0)
+        val origin = Waypoint.Origin("world", Point3D(0.0, 64.0, 0.0)) // 500 blocks (~116s) from a
+
+        val route = rightOrFail(
+            RouteFinder.findRoute(listOf(a, b), listOf(rail("ab", a, b, 10)), origin, b, maxWalkSeconds = 60.0)
+        )
+        assertEquals(TravelMode.WALK, route.legs.first().mode)
+        assertNull(route.legs.first().from) // starts from the current location
+        assertEquals(TravelMode.RAIL, route.legs.last().mode)
+    }
+
+    @Test
     @DisplayName("returns SameStation when from equals to")
     fun sameStation() {
         val a = station("a", 0.0, 0.0)


### PR DESCRIPTION
## 概要

`/ar railway route` に `--rail-only`（`-r`）フラグを追加します。指定すると駅間の徒歩（乗り換え・目的駅への徒歩）を **徒歩 20 秒以内**（既定の歩行速度で約 86 ブロック）に制限し、できる限り鉄道だけを使う経路を探します。従来は遠距離の徒歩ショートカットが混ざり、10 回以上の徒歩乗り換えを含む経路が出ることがありました。

## 変更内容

- **`RouteFinder`**: `findRoute` に `maxWalkSeconds: Double?` を追加（`null` なら従来どおり無制限）。駅発の徒歩辺のみ所要時間でフィルタし、現在地（`Waypoint.Origin`）から最初の駅への徒歩は制限しない（制限すると駅の近くに居ない限り経路が引けなくなるため）。定数 `RAIL_ONLY_MAX_WALK_SECONDS = 20.0` を追加。
- **`RailwayRouteCommand`**: Cloud の presence フラグ `@Flag("rail-only", aliases = ["r"])` を追加。rail-only で経路が無い場合はヒント付きメッセージを表示。
- **`AdvanceRailway`**: `ManagerSetting.LIBERAL_FLAG_PARSING` を有効化。Cloud 2.1.0 の既定ではフラグはチェーン末尾にのみ挿入されるため、省略可能引数 `[second]` の後ろに置いた `--rail-only` が StationId パーサーに食われてしまう（`--rail-only` は ID の allowlist に合致してパース成功する）。liberal モードで最後のリテラル直後からフラグを解析できるようにする。

## テスト

- `RouteFinderTest`: 制限超過の乗り換え・終端徒歩の拒否、制限内（約 23 秒）の乗り換え許可、現在地起点の免除の 4 件を追加。
- `RealDataRouteTest`: 実データで fti→akmt が rail-only でも到達でき、徒歩区間がすべて制限以内であることを検証。
- `./gradlew build` 成功（全テストパス）。