### PR TITLE
🐛 check が redraw 後も誤検出する問題を修正 & --group/--station フィルタ追加

### DIFF
--- a/src/main/kotlin/dev/nikomaru/advancerailway/commands/railway/RailwayMainCommand.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/commands/railway/RailwayMainCommand.kt
@@ -17,8 +17,10 @@ import dev.nikomaru.advancerailway.storage.DataPaths
 import dev.nikomaru.advancerailway.storage.FileLoader
 import dev.nikomaru.advancerailway.storage.model.RailwayData
 import dev.nikomaru.advancerailway.storage.type.LineType
+import dev.nikomaru.advancerailway.domain.id.GroupId
 import dev.nikomaru.advancerailway.domain.id.IdValidation
 import dev.nikomaru.advancerailway.domain.id.RailwayId
+import dev.nikomaru.advancerailway.domain.id.StationId
 import dev.nikomaru.advancerailway.domain.service.RailwayUtils
 import dev.nikomaru.advancerailway.domain.service.RailwayVerifier
 import dev.nikomaru.advancerailway.domain.service.StationUtils
@@ -29,6 +31,7 @@ import org.bukkit.entity.Player
 import org.incendo.cloud.annotations.Argument
 import org.incendo.cloud.annotations.Command
 import org.incendo.cloud.annotations.CommandDescription
+import org.incendo.cloud.annotations.Flag
 import org.incendo.cloud.annotations.Permission
 
 @Command("ar|advancerailway railway")
@@ -175,15 +178,35 @@ class RailwayMainCommand {
      * V2 路線の経路が保存時から変わっていないか、開始点＋分岐フラグから再トレースして検証する。
      * 以前は起動時に自動実行していたが、未ロードチャンクの同期ロードで起動が重くなるため
      * コマンドでの手動実行に変更した。失敗行の [TP] で始点駅へ飛んで現地を確認できる。
+     *
+     * `--group` / `--station` で対象を絞れる（両方指定した場合は AND）。
      */
     @Command("check")
-    @CommandDescription("全 V2 路線の経路が保存時から変わっていないか検証します")
+    @CommandDescription("V2 路線の経路が保存時から変わっていないか検証します（--group/--station で絞り込み）")
     @Permission("advancerailway.railway.manage")
-    suspend fun check(sender: CommandSender) {
+    suspend fun check(
+        sender: CommandSender,
+        @Flag(
+            value = "group",
+            aliases = ["g"],
+            description = "指定グループに属する路線だけを検証します",
+        ) group: GroupId?,
+        @Flag(
+            value = "station",
+            aliases = ["s"],
+            description = "指定駅に接続している路線だけを検証します",
+        ) station: StationId?,
+    ) {
         sender.sendRichMessage("<gray>路線の経路を検証しています…")
-        val result = RailwayVerifier.verifyAll()
+        val result = RailwayVerifier.verifyAll { data ->
+            (group == null || data.group == group) &&
+                (station == null || data.fromStation == station || data.toStation == station)
+        }
         if (result.checked == 0) {
-            sender.sendRichMessage("<yellow>検証対象の V2 路線がありません。")
+            sender.sendRichMessage(
+                if (group != null || station != null) "<yellow>条件に一致する V2 路線がありません。"
+                else "<yellow>検証対象の V2 路線がありません。"
+            )
             return
         }
         for (problem in result.problems) {

--- a/src/main/kotlin/dev/nikomaru/advancerailway/domain/service/RailwayVerifier.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/domain/service/RailwayVerifier.kt
@@ -38,7 +38,8 @@ object RailwayVerifier {
 
     data class Result(val checked: Int, val problems: List<Problem>)
 
-    suspend fun verifyAll(): Result {
+    /** [filter] に一致した V2 路線だけを検証する（既定は全件）。 */
+    suspend fun verifyAll(filter: (RailwayData.V2) -> Boolean = { true }): Result {
         val files = DataPaths.railways.listFiles()?.filter { it.extension == "json" } ?: return Result(0, emptyList())
         var checked = 0
         val problems = mutableListOf<Problem>()
@@ -48,7 +49,7 @@ object RailwayVerifier {
             } catch (e: Exception) {
                 continue // 壊れたファイルは RailwayDataLoader が警告済み
             }
-            if (data !is RailwayData.V2) {
+            if (data !is RailwayData.V2 || !filter(data)) {
                 continue
             }
             checked++

--- a/src/main/kotlin/dev/nikomaru/advancerailway/storage/serialization/Serializer.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/storage/serialization/Serializer.kt
@@ -66,9 +66,10 @@ object Line3DSerializer: KSerializer<Line3D> {
     override fun deserialize(decoder: Decoder): Line3D {
         val points = decoder.decodeString().split(":").map { it.drop(1) }.map { it.dropLast(1) }.map { it.split(",") }
             .map { Point3D(it[0].toDouble(), it[1].toDouble(), it[2].toDouble()) }
+        // addPoint は共線点の圧縮を伴い、保存時と点列が変わりうる（redraw 直後でも
+        // /ar railway check が「経路変化」を誤検出していた原因）。保存された点列をそのまま復元する。
         val line = Line3D(points[0], points[1])
-        points.drop(2).forEach { line.addPoint(it) }
-
+        line.points = ArrayList(points)
         return line
     }
 

--- a/src/test/kotlin/dev/nikomaru/advancerailway/storage/serialization/SerializerTest.kt
+++ b/src/test/kotlin/dev/nikomaru/advancerailway/storage/serialization/SerializerTest.kt
@@ -86,6 +86,24 @@ class SerializerTest {
     }
 
     @Test
+    @DisplayName("Line3D deserialize preserves collinear points verbatim (no re-collapse)")
+    fun line3DDeserializePreservesCollinearPoints() {
+        // トレース結果には共線 3 点が残ることがある（addPoint の圧縮はカスケードを
+        // 再チェックしないため）。ロード時に addPoint を通し直すと点が減って
+        // 保存時と一致しなくなる回帰を固定する。
+        val line = Line3D(Point3D(0.0, 64.0, 0.0), Point3D(2.0, 64.0, 0.0))
+        line.points = arrayListOf(
+            Point3D(0.0, 64.0, 0.0),
+            Point3D(2.0, 64.0, 0.0),
+            Point3D(4.0, 64.0, 0.0),
+        )
+        val encoded = json.encodeToString(Line3DSerializer, line)
+        val decoded = json.decodeFromString(Line3DSerializer, encoded)
+        assertEquals(line.points, decoded.points)
+        assertEquals(encoded, json.encodeToString(Line3DSerializer, decoded))
+    }
+
+    @Test
     @DisplayName("Line3D deserialize throws on malformed input without a separator")
     fun line3DDeserializeThrowsOnMalformedInput() {
         assertThrows<Exception> {


### PR DESCRIPTION
## 概要
1. **redraw しても `/ar railway check` が「経路変化」を報告し続ける不具合を修正**
2. `/ar railway check` に `--group` / `--station` フィルタを追加

## 1. 誤検出の原因と修正
`Line3DSerializer.deserialize` が読み込み時に `addPoint()` を通して点列を再構築していた。`addPoint` は共線点の圧縮を行うが、圧縮後のカスケード（新たに共線になった3点組）を再チェックしないため、**トレース直後の保存データには共線3点が正当に残り得る**。その結果:

- redraw → トレース結果をファイルに保存（正しい）
- check → **ロード時に点が潰されて減る** → 再トレース結果（フル）と不一致 → 何度 redraw しても「経路変化」

さらに `getInclination` は方向の符号を区別しない（例: 北向きと南向きが同じ傾き扱い）ため、カーブ路線ではこの潰れが起きやすい。

修正: デシリアライズは保存された点列をそのまま復元する。ファイル自体は正しい点列を保持しているため、**既存データも再保存なしでこの修正だけで直る**。共線3点がロードで潰れない回帰テストを `SerializerTest` に追加。

## 2. check のフィルタ
- `/ar railway check --group <グループ>`（`-g`）— 指定グループに属する路線だけ
- `/ar railway check --station <駅>`（`-s`）— 指定駅に接続している路線だけ（from/to のどちらか一致）
- 両方指定した場合は AND

`RailwayVerifier.verifyAll` に述語引数（既定は全件）を追加して実現。

## テスト
- `./gradlew test` 通過（新規回帰テスト含む）