### PR TITLE
⬆️ Update GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -19,11 +19,11 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
 
-      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         name: Install pnpm
         with:
           version: 10
@@ -73,4 +73,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -119,11 +119,11 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '22'
 
-      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         name: Install pnpm
         with:
           version: 10


### PR DESCRIPTION
## 概要

docsデプロイ失敗の解消と、Node 20 deprecation警告への対応。

## docsデプロイ失敗の原因

run [31105524391](https://github.com/morinoparty/AdvanceRailway/actions/runs/31105524391) の attempt 1 で Pages デプロイが \`deployment_queued\` のまま4分以上詰まり、手動キャンセルされた際に \`deploy-pages\` の post ステップがコミットSHA (\`141a60e\`) をIDとする Pages デプロイメントを **cancelled 状態で確定**させた。以降の再実行はすべて同じ \`pages_build_version\`(同じSHA)を再利用するため、即座に「Deployment cancelled」で失敗する。

→ 新しいコミットをmasterに積めば新しいSHAでデプロイされ解消する。本PRのマージ自体が \`deploy_docs.yml\` を変更するためデプロイをトリガーする。

## Node 20 deprecation対応

| Action | Before | After |
|---|---|---|
| actions/setup-node | v4.4.0 | v7.0.0 |
| pnpm/action-setup | v4.1.0 | v6.0.10 |
| actions/deploy-pages | v4.0.5 | v5.0.0 |

- \`deploy_docs.yml\` と \`preview.yml\` の両方を更新
- setup-node v5+ の自動キャッシュはnpm限定のため、既存の手動pnpmキャッシュ構成に影響なし
- pnpm/action-setup v6 でも \`version\` 入力はそのまま利用可能
- checkout / cache / upload-pages-artifact は既に最新