### PR TITLE
⬆️ 依存関係をまとめて最新版へ更新

### DIFF
--- a/.github/workflows/check_pull_request.yml
+++ b/.github/workflows/check_pull_request.yml
@@ -18,15 +18,15 @@ jobs:
           status: pending
           context: Check pull request
 
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: 'temurin'
           java-version: '25'
 
       # Gradle キャッシュの設定（setup-gradle を使用）
-      - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+      - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
         with:
           cache-read-only: true  # PR では読み取り専用
 

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -30,7 +30,7 @@ jobs:
     outputs:
       commit_sha: ${{ steps.vars.outputs.commit_sha }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set short git commit SHA
         id: vars
@@ -51,15 +51,15 @@ jobs:
     env:
       COMMIT_SHORT_SHA: ${{ needs.setup.outputs.commit_sha }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: 'temurin'
           java-version: '25'
 
       # Gradle キャッシュの設定（setup-gradle を使用）
-      - uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
+      - uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
         with:
           cache-read-only: ${{ github.ref != 'refs/heads/master' }}
 
@@ -78,7 +78,7 @@ jobs:
 
       - name: Publish test results
         id: publish-test-results
-        uses: mikepenz/action-junit-report@e08919a3b1fb83a78393dfb775a9c37f17d8eea6 # v6.0.1
+        uses: mikepenz/action-junit-report@d9f48fc87bc235f7e214acf696ca5abc0a986f16 # v6.4.2
         if: success() || failure()
         with:
           report_paths: './**/build/test-results/test/TEST-*.xml'
@@ -117,7 +117,7 @@ jobs:
     env:
       COMMIT_SHORT_SHA: ${{ needs.setup.outputs.commit_sha }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -218,7 +218,7 @@ jobs:
     env:
       COMMIT_SHORT_SHA: ${{ needs.setup.outputs.commit_sha }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Get limit time
         id: limit-time

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: 'temurin'
           java-version: '25'

--- a/.github/workflows/upload.yml
+++ b/.github/workflows/upload.yml
@@ -14,9 +14,9 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
+      - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: 'temurin'
           java-version: '25'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-paperVersion = "26.1.2.build.72-stable"
+paperVersion = "26.2.build.116-stable"
 squaremapVersion = "1.3.15"
 mccoroutineVersion = "2.22.0"
 # Incendo Cloud コマンドフレームワーク（MoripaFishing 等 morinoparty 系プラグインと揃える）。
@@ -20,7 +20,9 @@ uuidCreatorVersion = "6.1.1"
 mineauthVersion = "0.3.6"
 mockbukkitVersion = "4.116.3"
 mockkVersion = "1.14.11"
-# MockBukkit 4.110.0 がターゲットとする paper-api（テスト実行時のみ使用）。
+# MockBukkit がターゲットとする paper-api（テスト実行時のみ使用）。
+# main の paperVersion（26.x）とは意図的に別管理にしている。MockBukkit を 26.x の paper-api で
+# 動かすと ServerMock の初期化に失敗するため、MockBukkit 側が対応するまでここは上げられない。
 paperTestVersion = "1.21.11-R0.1-SNAPSHOT"
 
 [libraries]
@@ -52,7 +54,7 @@ mockk = { group = "io.mockk", name = "mockk", version.ref = "mockkVersion" }
 paper-api-test = { group = "io.papermc.paper", name = "paper-api", version.ref = "paperTestVersion" }
 
 [plugins]
-run-paper = { id = "xyz.jpenilla.run-paper", version = "3.0.2" }
+run-paper = { id = "xyz.jpenilla.run-paper", version = "3.1.0" }
 resource-factory = { id = "xyz.jpenilla.resource-factory", version = "1.3.1" }
 shadow = { id = "com.gradleup.shadow", version = "9.6.1" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version = "2.4.10" }


### PR DESCRIPTION
## 概要

dependabot が個別に出していた更新（#207 / #205 / #202 / #198 / #195 / #160）をまとめて取り込みます。
dependabot の提案よりさらに新しい版が出ているものは、**最新版に合わせて**います。

## 更新内容

| 対象 | 変更 | 備考 |
| --- | --- | --- |
| `io.papermc.paper:paper-api` | `26.1.2.build.72-stable` → `26.2.build.116-stable` | #207 の提案は `build.112`。最新は `build.116` |
| `xyz.jpenilla.run-paper` | `3.0.2` → `3.1.0` | #202 |
| `actions/checkout` | v7.0.0 → v7.0.1 | #205 |
| `actions/setup-java` | v5.6.0 → v5.7.0 | #198 |
| `gradle/actions/setup-gradle` | v6.2.0 → v6.3.0 | #195 |
| `mikepenz/action-junit-report` | v6.0.1 → v6.4.2 | #160 |

アクションの SHA ピンは、いずれも GitHub API でタグの実体と一致することを確認済みです
（`gradle/actions` は annotated tag のため 1 段 dereference しています）。

## paperTestVersion は据え置き

#207 は `paperTestVersion` も `26.2.build.112-stable` へ上げる提案でしたが、**これは取り込んでいません**。

実際に上げて試したところ、`RailwayApiHandlerTest` が `initializationError` で失敗します
（MockBukkit の `ServerMock` が 26.x の paper-api では初期化できない）。
main の `paperVersion` とテスト用の `paperTestVersion` を分けているのは元々このためなので、
同じ提案が繰り返し来ても迷わないよう、**理由を版指定の隣にコメントとして残しました**。

MockBukkit 側が 26.x に対応したら上げられます。

## その他

以下のアクションは既に最新版のため変更なしです。

`actions/cache` v6.1.0 / `actions/deploy-pages` v5.0.0 / `actions/download-artifact` v8.0.1 /
`actions/setup-node` v7.0.0 / `actions/upload-artifact` v7.0.1 /
`actions/upload-pages-artifact` v5.0.0 / `pnpm/action-setup` v6.0.10

## 動作確認

- `./gradlew build` — コンパイル・テスト（172 件）ともにパス