### PR TITLE
🐛 ID 引数が UUID でしか通らない問題を修正

### DIFF
--- a/src/main/kotlin/dev/nikomaru/advancerailway/domain/id/EntityIds.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/domain/id/EntityIds.kt
@@ -18,9 +18,13 @@ import java.util.UUID
  * 以前は人間可読な文字列（`tokyo` など）がそのまま主キー兼ファイル名だったため、
  * 表示上の都合で ID を変えると全参照が壊れていた。現在その文字列は [Slug] として別に持ち、
  * エンティティ同士の参照はここで定義する UUID だけを使う。
+ *
+ * **value class にはしない。** value class はコンパイル時に [UUID] へインライン展開され、
+ * コマンドハンドラの引数型も JVM 上では [UUID] になってしまう。すると Cloud が
+ * [dev.nikomaru.advancerailway.commands.parser.StationIdParser] ではなく組み込みの UUID パーサーを
+ * 選び、slug や駅名でコマンドを実行できなくなる（回帰は CommandArgumentTypeTest が監視する）。
  */
-@JvmInline
-value class StationId(val value: UUID) {
+data class StationId(val value: UUID) {
     override fun toString(): String = value.toString()
 
     companion object {
@@ -32,8 +36,7 @@ value class StationId(val value: UUID) {
     }
 }
 
-@JvmInline
-value class RailwayId(val value: UUID) {
+data class RailwayId(val value: UUID) {
     override fun toString(): String = value.toString()
 
     companion object {
@@ -43,8 +46,7 @@ value class RailwayId(val value: UUID) {
     }
 }
 
-@JvmInline
-value class GroupId(val value: UUID) {
+data class GroupId(val value: UUID) {
     override fun toString(): String = value.toString()
 
     companion object {

--- a/src/test/kotlin/dev/nikomaru/advancerailway/commands/CommandArgumentTypeTest.kt
+++ b/src/test/kotlin/dev/nikomaru/advancerailway/commands/CommandArgumentTypeTest.kt
@@ -1,0 +1,99 @@
+/*
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
+ *
+ * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication along with this software.
+ * If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+package dev.nikomaru.advancerailway.commands
+
+import dev.nikomaru.advancerailway.commands.group.GroupEditCommand
+import dev.nikomaru.advancerailway.commands.group.GroupInfoCommand
+import dev.nikomaru.advancerailway.commands.group.GroupMainCommand
+import dev.nikomaru.advancerailway.commands.railway.RailwayEditCommand
+import dev.nikomaru.advancerailway.commands.railway.RailwayExploreCommand
+import dev.nikomaru.advancerailway.commands.railway.RailwayInfoCommand
+import dev.nikomaru.advancerailway.commands.railway.RailwayMainCommand
+import dev.nikomaru.advancerailway.commands.railway.RailwayRouteCommand
+import dev.nikomaru.advancerailway.commands.station.StationEditCommand
+import dev.nikomaru.advancerailway.commands.station.StationInfoCommand
+import dev.nikomaru.advancerailway.commands.station.StationMainCommand
+import dev.nikomaru.advancerailway.domain.id.GroupId
+import dev.nikomaru.advancerailway.domain.id.RailwayId
+import dev.nikomaru.advancerailway.domain.id.StationId
+import org.incendo.cloud.annotations.Command
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+/**
+ * コマンドハンドラの引数型が、Cloud のパーサ登録と噛み合う形で残っているかを見る。
+ *
+ * 主キーを `@JvmInline value class` にしていた頃、`StationId` はコンパイル時に [UUID] へ
+ * インライン展開され、ハンドラの JVM 上の引数型が [UUID] になっていた。その結果 Cloud は
+ * 登録済みの [dev.nikomaru.advancerailway.commands.parser.StationIdParser] ではなく組み込みの
+ * UUID パーサーを選び、`/ar station tp <slug>` や駅名での実行がすべて弾かれていた。
+ *
+ * 型の宣言だけを見ても気づけない壊れ方なので、コンパイル後のシグネチャを直接確認する。
+ */
+class CommandArgumentTypeTest {
+
+    private val commandClasses = listOf(
+        GeneralCommand::class.java,
+        StationMainCommand::class.java,
+        StationInfoCommand::class.java,
+        StationEditCommand::class.java,
+        RailwayMainCommand::class.java,
+        RailwayInfoCommand::class.java,
+        RailwayEditCommand::class.java,
+        RailwayExploreCommand::class.java,
+        RailwayRouteCommand::class.java,
+        GroupMainCommand::class.java,
+        GroupInfoCommand::class.java,
+        GroupEditCommand::class.java,
+    )
+
+    private fun commandMethods() = commandClasses.flatMap { type ->
+        type.declaredMethods.filter { it.isAnnotationPresent(Command::class.java) }.map { type to it }
+    }
+
+    @Test
+    @DisplayName("no command handler takes a raw UUID, which would bypass the id parsers")
+    fun noHandlerTakesRawUuid() {
+        val offenders = commandMethods()
+            .filter { (_, method) -> method.parameterTypes.any { it == UUID::class.java } }
+            .map { (type, method) -> "${type.simpleName}.${method.name}" }
+
+        assertTrue(
+            offenders.isEmpty(),
+            "これらのハンドラは UUID を直接受け取っており、slug や表示名で実行できません: $offenders",
+        )
+    }
+
+    @Test
+    @DisplayName("id arguments keep their declared types, so the registered parsers are used")
+    fun idArgumentsKeepTheirTypes() {
+        val idTypes = setOf(StationId::class.java, RailwayId::class.java, GroupId::class.java)
+        val handlersTakingIds = commandMethods()
+            .filter { (_, method) -> method.parameterTypes.any { it in idTypes } }
+
+        // ID を取るハンドラが 1 つも見つからなければ、インライン展開などで型が消えている。
+        assertTrue(
+            handlersTakingIds.size >= 10,
+            "ID 型を引数に取るハンドラが ${handlersTakingIds.size} 件しかありません（型が消えている可能性）",
+        )
+    }
+
+    @Test
+    @DisplayName("station tp takes a StationId, so it accepts a slug or a display name")
+    fun stationTpTakesStationId() {
+        val tp = StationMainCommand::class.java.declaredMethods.single { it.name == "tp" }
+        assertTrue(
+            tp.parameterTypes.any { it == StationId::class.java },
+            "/ar station tp の引数が StationId ではありません: ${tp.parameterTypes.map { it.simpleName }}",
+        )
+    }
+}

--- a/src/test/kotlin/dev/nikomaru/advancerailway/commands/parser/IdEntriesTest.kt
+++ b/src/test/kotlin/dev/nikomaru/advancerailway/commands/parser/IdEntriesTest.kt
@@ -1,0 +1,134 @@
+/*
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
+ *
+ * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication along with this software.
+ * If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+package dev.nikomaru.advancerailway.commands.parser
+
+import dev.nikomaru.advancerailway.domain.geometry.Point3D
+import dev.nikomaru.advancerailway.domain.id.GroupId
+import dev.nikomaru.advancerailway.domain.id.RailwayId
+import dev.nikomaru.advancerailway.domain.id.Slug
+import dev.nikomaru.advancerailway.domain.id.StationId
+import dev.nikomaru.advancerailway.storage.database.DatabaseInitializer
+import dev.nikomaru.advancerailway.storage.database.repository.GroupRepository
+import dev.nikomaru.advancerailway.storage.database.repository.RailwayRepository
+import dev.nikomaru.advancerailway.storage.database.repository.StationRepository
+import dev.nikomaru.advancerailway.storage.model.GroupData
+import dev.nikomaru.advancerailway.storage.model.RailwayData
+import dev.nikomaru.advancerailway.storage.model.StationData
+import dev.nikomaru.advancerailway.storage.type.LineType
+import dev.nikomaru.advancerailway.domain.geometry.Line3D
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.exposed.v1.jdbc.deleteAll
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.awt.Color
+import java.nio.file.Files
+
+/**
+ * コマンド補完・引数解決がデータベースの実データから組み立てられているかを見る。
+ *
+ * `/ar station tp <駅>` のような引数は、プレイヤーが **駅名か slug** を打つ想定で、
+ * UUID を覚えて打つことは無い。[IdEntries] が名前と slug の両方を載せ、
+ * [IdIndex] がそれを ID に解決できることをここで固定する。
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class IdEntriesTest {
+
+    private val stations = StationRepository()
+    private val railways = RailwayRepository()
+    private val groups = GroupRepository()
+    private lateinit var dataFolder: java.io.File
+
+    @BeforeAll
+    fun setup(): Unit = runBlocking {
+        dataFolder = Files.createTempDirectory("advancerailway-identries-test").toFile()
+        DatabaseInitializer.connect("jdbc:sqlite:${dataFolder.resolve("test.db").absolutePath}")
+        DatabaseInitializer.createTables()
+        transaction { DatabaseInitializer.ALL_TABLES.reversed().forEach { it.deleteAll() } }
+
+        val group = GroupData(GroupId.new(), Slug("ym"), "山手線", Color.GREEN).also { groups.insert(it) }
+        val fti = station("fti", "ふれんちとーす島")
+        val akmt = station("akmt", "赤松")
+        railways.insert(
+            RailwayData(
+                id = RailwayId.new(),
+                slug = Slug("fti_akmt"),
+                group = group.id,
+                worldName = "world",
+                lineType = LineType.UP_DOWN_LINE,
+                line = Line3D(Point3D(0.0, 64.0, 0.0), Point3D(1.0, 64.0, 0.0)),
+                fromStation = fti.id,
+                toStation = akmt.id,
+                timeRequired = 60L,
+                startPoint = Point3D(0.0, 64.0, 0.0),
+                endPoint = Point3D(1.0, 64.0, 0.0),
+                flags = "E",
+            )
+        )
+    }
+
+    @AfterAll
+    fun tearDown() {
+        dataFolder.deleteRecursively()
+    }
+
+    @Test
+    @DisplayName("station suggestions offer display names, and both the name and the slug resolve")
+    fun stationsResolveByNameAndSlug() = runBlocking {
+        val entries = IdEntries.stations()
+        val fti = stations.findBySlug(Slug("fti"))!!
+
+        assertEquals(setOf("ふれんちとーす島", "赤松"), IdIndex.suggestions(entries))
+        assertEquals(fti.id.value, IdIndex.resolve(entries, "ふれんちとーす島"))
+        assertEquals(fti.id.value, IdIndex.resolve(entries, "fti"))
+        assertEquals(fti.id.value, IdIndex.resolve(entries, fti.id.value.toString()))
+        assertNull(IdIndex.resolve(entries, "存在しない駅"))
+    }
+
+    @Test
+    @DisplayName("group suggestions offer display names, and both the name and the slug resolve")
+    fun groupsResolveByNameAndSlug() = runBlocking {
+        val entries = IdEntries.groups()
+        val group = groups.findBySlug(Slug("ym"))!!
+
+        assertEquals(setOf("山手線"), IdIndex.suggestions(entries))
+        assertEquals(group.id.value, IdIndex.resolve(entries, "山手線"))
+        assertEquals(group.id.value, IdIndex.resolve(entries, "ym"))
+    }
+
+    @Test
+    @DisplayName("railways have no display name, so they are suggested and resolved by slug")
+    fun railwaysResolveBySlug() = runBlocking {
+        val entries = IdEntries.railways()
+        val railway = railways.findBySlug(Slug("fti_akmt"))!!
+
+        assertEquals(setOf("fti_akmt"), IdIndex.suggestions(entries))
+        assertEquals(railway.id.value, IdIndex.resolve(entries, "fti_akmt"))
+    }
+
+    private suspend fun station(slug: String, name: String): StationData {
+        val data = StationData(
+            id = StationId.new(),
+            slug = Slug(slug),
+            name = name,
+            worldName = "world",
+            point = Point3D(0.0, 64.0, 0.0),
+            overrideSize = null,
+            color = Color.WHITE,
+        )
+        stations.insert(data)
+        return data
+    }
+}


### PR DESCRIPTION
## 症状

`/ar station tp <駅>` をはじめ、**ID を引数に取るコマンドが slug でも駅名でも通らず、UUID を直接打つしかない**状態でした。

## 原因

主キーの `StationId` / `RailwayId` / `GroupId` を `@JvmInline value class` にしていたためです。

value class はコンパイル時に中身の型へインライン展開されるので、ハンドラの JVM 上のシグネチャが `java.util.UUID` になります（メソッド名も `tp-GSuXAEU` のようにマングルされます）。

```
$ javap StationMainCommand   # 修正前
public final Object tp-GSuXAEU(CommandSender, java.util.UUID, Continuation)
```

Cloud は引数の型でパーサーを選ぶため、登録済みの `StationIdParser`（表示名 → slug → UUID の順で解決する）ではなく、**組み込みの UUID パーサー**が使われていました。

影響は `station tp` だけではなく、**ID を引数に取る 26 個のハンドラすべて**です（station の remove/info/set\*、railway の info/remove/check/set\*/explore/route、group の info/remove/set\*/station\*）。

## 修正

3 つの ID 型を `data class` に変更し、JVM 上でも型が残るようにしました。

```
$ javap StationMainCommand   # 修正後
public final Object tp(CommandSender, dev.nikomaru.advancerailway.domain.id.StationId, Continuation)
```

value class にしてはいけない理由は、宣言のすぐそばに KDoc として残しています。

## 回帰テスト

型の宣言だけを見ても気づけない壊れ方なので、2 つの角度から固定しました。

- **`CommandArgumentTypeTest`** — コンパイル後のシグネチャを反射で確認し、`@Command` の付いたハンドラが `UUID` を直接受け取っていないことを検証します。
- **`IdEntriesTest`** — 実データベースに対して、駅名・slug・UUID のどれでも ID に解決できることを検証します。

`CommandArgumentTypeTest` が実際にこの不具合を捕まえることを、一時的に value class へ戻して確認しました。3 件とも失敗し、影響を受けていた 26 ハンドラがすべて列挙されます。

```
これらのハンドラは UUID を直接受け取っており、slug や表示名で実行できません:
[StationMainCommand.remove-GSuXAEU, StationMainCommand.tp-GSuXAEU, ... GroupEditCommand.stationList-X_pcoVE]
```

## 動作確認

- `./gradlew build` — コンパイル・テスト（178 件）ともにパス