### PR TITLE
🐛 inspect の [作成] リンクが消える問題を修正し、slug を併記する

### DIFF
--- a/src/main/kotlin/dev/nikomaru/advancerailway/commands/CommandUtils.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/commands/CommandUtils.kt
@@ -22,6 +22,25 @@ import java.time.format.DateTimeFormatter
  */
 fun esc(text: String): String = text.replace("<", "\\<")
 
+/**
+ * 表示名と slug を併記する（`名前 (slug)`）。
+ *
+ * 表示名は覚えやすいが一意とは限らず、slug はコマンドにそのまま打てる。どちらか一方だけを出すと
+ * 「見えている名前でコマンドを打ったら通らない」「slug しか出ないので何の駅か分からない」の
+ * どちらかが起きるため、一覧・詳細・inspect のいずれでも両方を出す。
+ *
+ * 名前はユーザー由来なので必ず [esc] を通す。エスケープを忘れると、名前に含まれる `<` が
+ * MiniMessage のタグとして解釈され、**その後ろに続く `[作成]` などのリンクごと消える**。
+ */
+fun nameWithSlug(name: String, slug: Slug): String =
+    "<white>${esc(name)}</white> <dark_gray>(${slug.value})</dark_gray>"
+
+/**
+ * タグを含まない形の併記（`名前 (slug)`）。
+ * 後段でまとめて [esc] を掛ける経路（経路表示のラベルなど）で使う。
+ */
+fun nameWithSlugPlain(name: String, slug: Slug): String = "$name (${slug.value})"
+
 /** [Color] を MiniMessage の `<color:#RRGGBB>` で使える `#RRGGBB` 形式にする。 */
 fun Color.toHex(): String = "#%02X%02X%02X".format(red, green, blue)
 

--- a/src/main/kotlin/dev/nikomaru/advancerailway/commands/railway/RailwayInfoCommand.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/commands/railway/RailwayInfoCommand.kt
@@ -10,6 +10,7 @@
 package dev.nikomaru.advancerailway.commands.railway
 
 import dev.nikomaru.advancerailway.commands.esc
+import dev.nikomaru.advancerailway.commands.nameWithSlug
 import dev.nikomaru.advancerailway.commands.formatCheckedAt
 import dev.nikomaru.advancerailway.commands.formatMinutes
 import dev.nikomaru.advancerailway.commands.sendPaginated
@@ -47,8 +48,8 @@ class RailwayInfoCommand : KoinComponent {
         val slug = data.slug.value
         val fromStation = stationRepository.findById(data.fromStation)
         val toStation = stationRepository.findById(data.toStation)
-        val fromName = fromStation?.name ?: data.fromStation.toString()
-        val toName = toStation?.name ?: data.toStation.toString()
+        val fromLabel = fromStation?.let { nameWithSlug(it.name, it.slug) } ?: "<gray>${data.fromStation}</gray>"
+        val toLabel = toStation?.let { nameWithSlug(it.name, it.slug) } ?: "<gray>${data.toStation}</gray>"
         val groupData = data.group?.let { groupRepository.findById(it) }
 
         sender.sendRichMessage(
@@ -68,9 +69,7 @@ class RailwayInfoCommand : KoinComponent {
                     "<click:suggest_command:'/ar railway set group $slug <group>'><dark_gray>[編集]</dark_gray></click>"
             )
         }
-        sender.sendRichMessage(
-            "<gray>区間: <white>${esc(fromName)}</white> <yellow>→</yellow> <white>${esc(toName)}</white>"
-        )
+        sender.sendRichMessage("<gray>区間: $fromLabel <yellow>→</yellow> $toLabel")
         sender.sendRichMessage("<gray>所要時間: <white>${formatMinutes(data.timeRequired)}</white>")
         sender.sendRichMessage(
             "<gray>種別: <white>${data.lineType}</white> " +
@@ -92,7 +91,7 @@ class RailwayInfoCommand : KoinComponent {
     @Permission("advancerailway.railway.view")
     suspend fun list(sender: CommandSender, @Argument("page") @Default("1") page: Int) {
         val railways = railwayRepository.findAll()
-        val stationNames = stationRepository.findAll().associate { it.id to it.name }
+        val stationLabels = stationRepository.findAll().associate { it.id to nameWithSlug(it.name, it.slug) }
         val groups = groupRepository.findAll().associateBy { it.id }
         sender.sendPaginated(
             items = railways,
@@ -102,13 +101,13 @@ class RailwayInfoCommand : KoinComponent {
             pageCommand = "/ar railway list",
         ) {
             val slug = it.slug.value
-            val fromName = stationNames[it.fromStation] ?: it.fromStation.toString()
-            val toName = stationNames[it.toStation] ?: it.toStation.toString()
+            val fromLabel = stationLabels[it.fromStation] ?: "<gray>${it.fromStation}</gray>"
+            val toLabel = stationLabels[it.toStation] ?: "<gray>${it.toStation}</gray>"
             val marker = it.group?.let { g -> groups[g] }
                 ?.let { gd -> "<color:${gd.railwayColor.toHex()}>■</color>" }
                 ?: "<gray>■</gray>"
             "$marker <white>$slug</white> " +
-                "<gray>${esc(fromName)} <yellow>→</yellow> ${esc(toName)}</gray> " +
+                "$fromLabel <yellow>→</yellow> $toLabel " +
                 "<dark_gray>(${formatMinutes(it.timeRequired)})</dark_gray> " +
                 "<click:run_command:/ar railway info $slug><dark_gray>[詳細]</dark_gray></click>"
         }

--- a/src/main/kotlin/dev/nikomaru/advancerailway/commands/railway/RailwayRouteCommand.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/commands/railway/RailwayRouteCommand.kt
@@ -10,6 +10,7 @@
 package dev.nikomaru.advancerailway.commands.railway
 
 import arrow.core.Either
+import dev.nikomaru.advancerailway.commands.nameWithSlugPlain
 import dev.nikomaru.advancerailway.domain.id.GroupId
 import dev.nikomaru.advancerailway.domain.id.StationId
 import dev.nikomaru.advancerailway.domain.route.RailEdge
@@ -82,8 +83,9 @@ class RailwayRouteCommand : KoinComponent {
     ) {
         val stationData = stationRepository.findAll()
         val stations = stationData.map { it.toNode() }
-        val stationNames = stationData.associate { it.id to it.name }
-        val labels = stationData.associate { it.id to (it.name.takeIf { n -> n.isNotBlank() } ?: it.slug.value) }
+        // 表示名だけだと同名駅を見分けられず、そのままコマンドに打てるとも限らないので slug も添える。
+        val stationNames = stationData.associate { it.id to nameWithSlugPlain(it.name, it.slug) }
+        val labels = stationNames
         if (second == null) {
             // route <to>: 現在地から first へ。
             val player = sender as? Player ?: run {

--- a/src/main/kotlin/dev/nikomaru/advancerailway/commands/station/StationInfoCommand.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/commands/station/StationInfoCommand.kt
@@ -10,6 +10,7 @@
 package dev.nikomaru.advancerailway.commands.station
 
 import dev.nikomaru.advancerailway.commands.esc
+import dev.nikomaru.advancerailway.commands.nameWithSlug
 import dev.nikomaru.advancerailway.commands.sendPaginated
 import dev.nikomaru.advancerailway.commands.toHex
 import dev.nikomaru.advancerailway.domain.id.StationId
@@ -56,7 +57,7 @@ class StationInfoCommand : KoinComponent {
                 val groupHex = entry.group.railwayColor.toHex()
                 val numbering = entry.numbering ?: "—"
                 sender.sendRichMessage(
-                    "  <color:$groupHex>■</color> <white>${esc(entry.group.name)}</white> " +
+                    "  <color:$groupHex>■</color> ${nameWithSlug(entry.group.name, entry.group.slug)} " +
                         "<gray>· ${entry.position + 1} 番目 · </gray><white>$numbering</white>"
                 )
             }

--- a/src/main/kotlin/dev/nikomaru/advancerailway/listener/InspectMessage.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/listener/InspectMessage.kt
@@ -1,0 +1,74 @@
+/*
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
+ *
+ * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication along with this software.
+ * If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+package dev.nikomaru.advancerailway.listener
+
+import dev.nikomaru.advancerailway.commands.nameWithSlug
+import dev.nikomaru.advancerailway.domain.geometry.Point3D
+import dev.nikomaru.advancerailway.domain.rail.BranchEndpoint
+import dev.nikomaru.advancerailway.domain.rail.EndpointKind
+import dev.nikomaru.advancerailway.storage.model.StationData
+
+/**
+ * `/ar inspect` が返す終端 1 行の組み立て。
+ *
+ * Bukkit にもデータベースにも依存しない純粋な文字列生成にしてある。`[作成]` のリンクが
+ * 出るかどうかは「クリックしてすぐ路線を登録できるか」を決める要なのに、実際にレールを
+ * 敷いた状態でしか確認できないと壊れても気づけないため、ここだけ切り出してテストできるようにした。
+ */
+internal object InspectMessage {
+
+    /** 行頭の `[flags: EE]` と終端の種別。 */
+    fun label(endpoint: BranchEndpoint): String = buildString {
+        append("<yellow>[flags: ${endpoint.flagString()}]</yellow> ")
+        when (endpoint.kind) {
+            EndpointKind.STOP_BLOCK -> append("<gold>[停止ブロック]</gold> ")
+            EndpointKind.LOOP -> append("<gray>[環状/合流]</gray> ")
+            EndpointKind.RAIL_END -> {}
+        }
+    }
+
+    /**
+     * 終端 1 件の表示行を組み立てる。
+     *
+     * @param flags `/ar railway add` にそのまま渡せるフラグ列。算出できない向きでは null で、
+     *   その場合 `[作成]` は出さない（誤ったフラグで登録させないため）。
+     * @return 送信する行。始点と終点の最寄り駅が同じ（自駅へ戻ってくる経路）の場合は null。
+     */
+    fun endpointLine(
+        label: String,
+        startStation: StationData?,
+        endStation: StationData?,
+        start: Point3D,
+        end: Point3D,
+        flags: String?,
+    ): String? {
+        if (startStation != null && startStation.id == endStation?.id) {
+            // 自分の駅に戻ってくる経路は表示しない
+            return null
+        }
+        if (startStation == null || endStation == null) {
+            return "$label<white>${start.toPlainString()} -> ${end.toPlainString()}</white> " +
+                "<gray>(付近に駅が登録されていません)"
+        }
+        val suggest = if (flags.isNullOrEmpty()) {
+            ""
+        } else {
+            val slug = "${startStation.slug.value}_${endStation.slug.value}"
+            " <click:suggest_command:'/ar railway add $slug ${start.toPlainString()} " +
+                "${end.toPlainString()} $flags'><green>[作成]</green></click>"
+        }
+        // 駅名は必ず nameWithSlug 経由で出す。エスケープを挟まないと、名前に含まれる `<` が
+        // MiniMessage のタグとして解釈され、後ろの [作成] リンクごと表示から消える。
+        return "$label${nameWithSlug(startStation.name, startStation.slug)} " +
+            "<gray>${start.toPlainString()}</gray> <yellow>-></yellow> " +
+            "${nameWithSlug(endStation.name, endStation.slug)} " +
+            "<gray>${end.toPlainString()}</gray>$suggest"
+    }
+}

--- a/src/main/kotlin/dev/nikomaru/advancerailway/listener/RailClickEvent.kt
+++ b/src/main/kotlin/dev/nikomaru/advancerailway/listener/RailClickEvent.kt
@@ -13,7 +13,7 @@ import arrow.core.Either
 import dev.nikomaru.advancerailway.domain.geometry.Point3D
 import dev.nikomaru.advancerailway.domain.rail.BranchDirection
 import dev.nikomaru.advancerailway.domain.rail.BranchEndpoint
-import dev.nikomaru.advancerailway.domain.rail.EndpointKind
+import dev.nikomaru.advancerailway.AdvanceRailway
 import dev.nikomaru.advancerailway.domain.error.toUserMessage
 import dev.nikomaru.advancerailway.domain.service.RailwayUtils
 import dev.nikomaru.advancerailway.domain.service.RailwayUtils.railEndpointInspect
@@ -26,8 +26,12 @@ import org.bukkit.entity.Player
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
 import org.bukkit.event.player.PlayerInteractEvent
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
 
-class RailClickEvent: Listener {
+class RailClickEvent: Listener, KoinComponent {
+    private val plugin: AdvanceRailway by inject()
+
     companion object {
         val detect = arrayListOf<Player>()
     }
@@ -56,37 +60,38 @@ class RailClickEvent: Listener {
             } else {
                 player.sendRichMessage("<gray>このレールは線路の途中です。")
             }
-            when (val result = railEndpointInspect(startPoint, player.world)) {
-                is Either.Right -> {
-                    player.sendRichMessage("<green>${result.value.size} 件の終端を検出しました。")
-                    result.value.forEach { endpoint ->
-                        sendEndpoint(player, endpoint)
+            // 例外をそのまま伝播させると、プレイヤーには「探索しています…」だけが残って
+            // 何が起きたのか分からない（原因はコンソールのログにしか出ない）。ここで拾って伝える。
+            try {
+                when (val result = railEndpointInspect(startPoint, player.world)) {
+                    is Either.Right -> {
+                        player.sendRichMessage("<green>${result.value.size} 件の終端を検出しました。")
+                        result.value.forEach { endpoint ->
+                            sendEndpoint(player, endpoint)
+                        }
+                    }
+
+                    is Either.Left -> {
+                        player.sendRichMessage(result.value.toUserMessage())
                     }
                 }
-
-                is Either.Left -> {
-                    player.sendRichMessage(result.value.toUserMessage())
-                }
+            } catch (e: Exception) {
+                plugin.logger.warning("inspect failed for ${player.name}: ${e.message}")
+                player.sendRichMessage("<red>解析に失敗しました: <white>${e.message}</white>")
             }
         }
     }
 
     /**
-     * 終端1件を forward（クリック点→終端）・backward（終端→クリック点）の2行で表示する。
+     * 終端 1 件を forward（クリック点→終端）・backward（終端→クリック点）の 2 行で表示する。
      * flags の先頭は出発方角で、そのまま railway add の flags 引数に使える。
-     * 始点と終点の最寄り駅が同じ（自駅に戻ってくる）経路は表示しない。
      * backward の分岐フラグは逆走時の分岐の現れ方が異なり算出していないため、
      * 途中分岐なし（flags が出発方角のみ）の場合のみ [作成] を出す。
+     *
+     * 行の組み立て自体は [InspectMessage] が持つ（レールを敷かずにテストできるようにするため）。
      */
     private suspend fun sendEndpoint(player: Player, endpoint: BranchEndpoint) {
-        val label = buildString {
-            append("<yellow>[flags: ${endpoint.flagString()}]</yellow> ")
-            when (endpoint.kind) {
-                EndpointKind.STOP_BLOCK -> append("<gold>[停止ブロック]</gold> ")
-                EndpointKind.LOOP -> append("<gray>[環状/合流]</gray> ")
-                EndpointKind.RAIL_END -> {}
-            }
-        }
+        val label = InspectMessage.label(endpoint)
         val backwardFlags = endpoint.backward.let { backward ->
             val start = backward.start
             val direction = backward.direction
@@ -102,29 +107,15 @@ class RailClickEvent: Listener {
         ).forEach { (data, flags) ->
             val start = data.start ?: return@forEach
             val end = data.end ?: return@forEach
-            val startStation = StationUtils.nearStation(start.toLocation(player.world))
-            val endStation = StationUtils.nearStation(end.toLocation(player.world))
-            if (startStation != null && startStation == endStation) {
-                // 自分の駅に戻ってくる経路は表示しない
-                return@forEach
-            }
-            if (startStation == null || endStation == null) {
-                player.sendRichMessage(
-                    "$label<white>${start.toPlainString()} -> ${end.toPlainString()}</white> <gray>(付近に駅が登録されていません)"
-                )
-                return@forEach
-            }
-            val suggestSlug = startStation.slug.value + "_" + endStation.slug.value
-            val suggestMessage = if (flags != null) {
-                " <click:suggest_command:'/ar railway add $suggestSlug ${start.toPlainString()} " +
-                    "${end.toPlainString()} $flags'><green>[作成]</green></click>"
-            } else {
-                ""
-            }
-            player.sendRichMessage(
-                "$label<white>${startStation.name} : ${start.toPlainString()} -> " +
-                    "${endStation.name} : ${end.toPlainString()}</white>$suggestMessage"
-            )
+            val line = InspectMessage.endpointLine(
+                label = label,
+                startStation = StationUtils.nearStation(start.toLocation(player.world)),
+                endStation = StationUtils.nearStation(end.toLocation(player.world)),
+                start = start,
+                end = end,
+                flags = flags,
+            ) ?: return@forEach
+            player.sendRichMessage(line)
         }
     }
 }

--- a/src/test/kotlin/dev/nikomaru/advancerailway/listener/InspectMessageTest.kt
+++ b/src/test/kotlin/dev/nikomaru/advancerailway/listener/InspectMessageTest.kt
@@ -1,0 +1,129 @@
+/*
+ * Written in 2024-2026 by Nikomaru <nikomaru@nikomaru.dev>
+ *
+ * To the extent possible under law, the author(s) have dedicated all copyright and related and neighboring rights to this software to the public domain worldwide.This software is distributed without any warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication along with this software.
+ * If not, see <http://creativecommons.org/publicdomain/zero/1.0/>.
+ */
+
+package dev.nikomaru.advancerailway.listener
+
+import dev.nikomaru.advancerailway.domain.geometry.Point3D
+import dev.nikomaru.advancerailway.domain.id.Slug
+import dev.nikomaru.advancerailway.domain.id.StationId
+import dev.nikomaru.advancerailway.storage.model.StationData
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import java.awt.Color
+
+/**
+ * `/ar inspect` の終端 1 行（[InspectMessage]）のテスト。
+ *
+ * ここで守りたいのは **`[作成]` のリンクが確実に出ること**。inspect の価値はクリックだけで
+ * `ar railway add` を組み立てられる点にあり、実際にレールを敷いた状態でしか動かせない場所に
+ * 置いておくと、壊れても気づけないまま出荷されてしまう。
+ */
+class InspectMessageTest {
+
+    private val start = Point3D(1.0, 64.0, -3.0)
+    private val end = Point3D(5.0, 64.0, 10.0)
+
+    private fun station(slug: String, name: String) = StationData(
+        id = StationId.new(),
+        slug = Slug(slug),
+        name = name,
+        worldName = "world",
+        point = Point3D(0.0, 64.0, 0.0),
+        overrideSize = null,
+        color = Color.WHITE,
+    )
+
+    private fun line(
+        from: StationData? = station("fti", "ふれんちとーす島"),
+        to: StationData? = station("akmt", "赤松"),
+        flags: String? = "EE",
+    ) = InspectMessage.endpointLine("<yellow>[flags: EE]</yellow> ", from, to, start, end, flags)
+
+    @Test
+    @DisplayName("the line offers a clickable [作成] with a ready-to-run railway add command")
+    fun offersCreateLink() {
+        val message = line()!!
+
+        assertTrue(message.contains("[作成]"), "[作成] が出ていません: $message")
+        assertTrue(
+            message.contains("/ar railway add fti_akmt ${start.toPlainString()} ${end.toPlainString()} EE"),
+            "組み立てられたコマンドが期待と違います: $message",
+        )
+    }
+
+    @Test
+    @DisplayName("both the display name and the slug are shown for each endpoint")
+    fun showsNameAndSlug() {
+        val message = line()!!
+
+        assertTrue(message.contains("ふれんちとーす島"), message)
+        assertTrue(message.contains("(fti)"), message)
+        assertTrue(message.contains("赤松"), message)
+        assertTrue(message.contains("(akmt)"), message)
+    }
+
+    @Test
+    @DisplayName("a station name containing '<' is escaped and does not swallow the [作成] link")
+    fun escapesStationNameSoTheLinkSurvives() {
+        // MiniMessage は `<` からをタグとして読むため、エスケープを忘れると駅名の後ろ
+        // （＝[作成] リンク）が丸ごと表示から消える。
+        val message = line(from = station("heart", "<3の駅"))!!
+
+        assertTrue(message.contains("\\<3の駅"), "駅名がエスケープされていません: $message")
+        // 生の `<` が残っていないこと（エスケープ済みの `\<` は直前のバックスラッシュで判定する）。
+        val raw = message.indexOf("<3の駅")
+        assertTrue(raw > 0 && message[raw - 1] == '\\', "駅名の `<` が生のまま残っています: $message")
+        assertTrue(message.contains("[作成]"), "エスケープ漏れで [作成] が消えています: $message")
+        assertTrue(message.indexOf("[作成]") > raw, "[作成] が駅名より前にあります: $message")
+    }
+
+    @Test
+    @DisplayName("no [作成] when the flags for that direction could not be derived")
+    fun noCreateLinkWithoutFlags() {
+        val message = line(flags = null)!!
+
+        assertFalse(message.contains("[作成]"), "フラグ不明なのに [作成] が出ています: $message")
+        // 駅の情報自体は出す（どこへ繋がっているかは分かるようにする）。
+        assertTrue(message.contains("ふれんちとーす島"), message)
+    }
+
+    @Test
+    @DisplayName("no [作成] when the flags are empty, which would build an invalid command")
+    fun noCreateLinkWithEmptyFlags() {
+        assertFalse(line(flags = "")!!.contains("[作成]"))
+    }
+
+    @Test
+    @DisplayName("a route that returns to its own station is skipped entirely")
+    fun skipsSelfReturningRoute() {
+        val same = station("fti", "ふれんちとーす島")
+        assertNull(InspectMessage.endpointLine("", same, same, start, end, "EE"))
+    }
+
+    @Test
+    @DisplayName("without a nearby station the coordinates are still reported, with no [作成]")
+    fun reportsMissingStation() {
+        val message = line(to = null)!!
+
+        assertTrue(message.contains("付近に駅が登録されていません"), message)
+        assertFalse(message.contains("[作成]"), message)
+        assertTrue(message.contains(start.toPlainString()), message)
+    }
+
+    @Test
+    @DisplayName("the label prefix carries the flags and the endpoint kind")
+    fun labelCarriesFlagsAndKind() {
+        val message = line()!!
+        assertEquals(true, message.startsWith("<yellow>[flags: EE]</yellow> "), message)
+    }
+}


### PR DESCRIPTION
## 1. inspect の `[作成]` が出ない

### 原因

`/ar inspect` の終端表示だけ、**ユーザー由来の駅名を MiniMessage 用にエスケープしていませんでした**。他の表示はすべて `esc()` を通しているのに、この listener だけ漏れていました。

駅名に `<` が含まれると MiniMessage がそこからタグとして読み始めるため、**名前の後ろに続く `[作成]` リンクごと表示から消えます**。

```
<white><3の駅</white> ... <click:suggest_command:'...'><green>[作成]</green></click>
       ^^^^ ここからタグ扱いになり、以降が壊れる
```

### 修正

- 行の組み立てを `InspectMessage` に切り出し、**レールを敷かなくてもテストできる**ようにしました
- 駅名は必ず `nameWithSlug()` 経由にして、エスケープを構造的に強制しています
- inspect 中に例外が出た場合、握りつぶさずプレイヤーにも伝えるようにしました
  （従来は「線路を探索しています…」のまま無言で終わり、原因はコンソールのログにしか出ませんでした）

### 補足

手元の headless 環境ではプレイヤーのクリックを再現できないため、**この修正で解決するかどうかの実機確認までは取れていません**。もし駅名に `<` が含まれていないのに `[作成]` が出ない場合は、
- 「(付近に駅が登録されていません)」が出ていないか
- 例外メッセージ（今回から表示されます）が出ていないか

を教えてください。原因の切り分けができます。

## 2. slug と表示名の併記

表示名だけだと同名の駅を見分けられず、そのままコマンドに打てるとも限らないため、両方を出すようにしました。

| 場所 | 変更 |
| --- | --- |
| `ar inspect` の終端 | 駅名 + slug |
| `ar railway info` の区間 | 駅名 + slug |
| `ar railway list` の駅 | 駅名 + slug |
| `ar station info` の所属路線 | 路線名 + slug |
| `ar railway route` の各区間 | 駅名 + slug |

`ar station list` / `ar group list` / `ar group info` / `ar group station list` は元々併記されていたため変更していません。路線（railway）は表示名を持たないので slug のみです。

共通ヘルパー `nameWithSlug()` に集約し、名前のエスケープもここで必ず掛かるようにしています。

## 回帰テスト

`InspectMessageTest` を追加しました。

- `[作成]` が出て、`/ar railway add <slug>_<slug> <start> <end> <flags>` が正しく組み立てられること
- **駅名に `<` が含まれてもエスケープされ、`[作成]` が消えないこと**
- フラグが不明・空のときは `[作成]` を出さないこと（不正なコマンドを打たせないため）
- 自駅へ戻る経路はスキップされること
- 近くに駅が無いときは座標だけ出ること
- 表示名と slug の両方が出ること

エスケープを外すとこのテストが落ちることを確認済みです。

## 動作確認

- `./gradlew build` — コンパイル・テスト（186 件）ともにパス